### PR TITLE
Add v0 technical spec

### DIFF
--- a/spec/overview.md
+++ b/spec/overview.md
@@ -48,7 +48,7 @@ CollateralConfig {
 }
 ```
 ### Methods
-`initiateAuction()` The entry-point which is called by a borrower to start the auction process. This function accepts an auction config, bond config, and collateral config. This is because in order to have a valid aucction, all three of these pices must be valid and set when the auction begins as the lenders need to have this information.
+`initiateAuction()` The entry-point which is called by a borrower to start the auction process. This function accepts an auction config, bond config, and collateral config. This is because in order to have a valid auction, all three of these pieces must be valid and set when the auction begins as the lenders need to have this information.
 
 Parameters
 ```


### PR DESCRIPTION
I think we should follow the [auditless specification framework](https://www.auditless.com/codex/how-to-write-a-specification ) to create a more technical protocol specification. 

The purpose of this specification will be two fold:
* Facilitate a common understanding of what needs build & get technical feedback from our advisors
* Help us focus our learning efforts on work directly relevant to our protocol 

https://github.com/porter-finance/litepaper#bond-implementation