### PR TITLE
add section for detailing auction flow

### DIFF
--- a/spec/bondAuction.md
+++ b/spec/bondAuction.md
@@ -72,3 +72,12 @@ bytes32[] memory _sellOrders
 
 `getAuctionConfig() view returns(AuctionConfig, BondConfig, CollateralConfig)` This function returns the auction config for a given auction.
 
+
+# End to End auction flow
+Example: DAI as borrowing asset
+Max interest rate: 10%
+Term length: 1 year
+Min issuance size: 50m
+Max issuance size: 100m
+
+Bonds may be sold in a mechanism other than an auction in the future - so we should keep that in mind when designing how we are storing collateral, repayment, etc


### PR DESCRIPTION
Improve auction flow by adding examples

Goal is to walk through the e2e auction flow with different parameters and figure out of all the parameters specified by https://docs.porter.finance/product/spec/pages/create_auction_page make sense and work with gnosis auction

I was planning on doing this - but @Namaskar-1F64F does this makes sense for you to do since you've been focused on auction? 