### PR TITLE
allow bond name and symbol to be passed in on frontend

### DIFF
--- a/contracts/BondFactoryClone.sol
+++ b/contracts/BondFactoryClone.sol
@@ -12,6 +12,8 @@ contract BondFactoryClone {
     }
 
     function createBond(
+        string memory _name,
+        string memory _symbol,
         address _owner,
         address _issuer,
         uint256 _maturityDate,
@@ -24,6 +26,8 @@ contract BondFactoryClone {
     ) external returns (address clone) {
         clone = Clones.clone(tokenImplementation);
         SimpleBond(clone).initialize(
+            _name, 
+            _symbol,
             _owner,
             _issuer,
             _maturityDate,

--- a/contracts/Broker/Broker.sol
+++ b/contracts/Broker/Broker.sol
@@ -64,6 +64,8 @@ contract Broker is Ownable, ReentrancyGuard {
     }
 
     function createBond(
+        string memory _name,
+        string memory _symbol,
         address _issuer,
         uint256 _maturityDate,
         uint256 _maxBondSupply,
@@ -74,6 +76,8 @@ contract Broker is Ownable, ReentrancyGuard {
         uint256 _convertibilityRatio
     ) external {
         address bond = IBondFactoryClone(bondFactoryAddress).createBond(
+            _name, 
+            _symbol,
             address(this),
             _issuer,
             _maturityDate,

--- a/contracts/Broker/interfaces/IBondFactoryClone.sol
+++ b/contracts/Broker/interfaces/IBondFactoryClone.sol
@@ -5,6 +5,8 @@ interface IBondFactoryClone {
     event BondCreated(address newBond);
 
     function createBond(
+        string memory _name,
+        string memory _symbol,
         address _owner,
         address _issuer,
         uint256 _maturityDate,

--- a/contracts/SimpleBond.sol
+++ b/contracts/SimpleBond.sol
@@ -181,6 +181,8 @@ contract SimpleBond is
     /// @dev The Auction contract will be the owner
     /// @param _maxBondSupply Total number of bonds being issued - this is determined by auction config
     function initialize(
+        string memory _name,
+        string memory _symbol,
         address _owner,
         address _issuer,
         uint256 _maturityDate,
@@ -199,7 +201,7 @@ contract SimpleBond is
 
         // This mints bonds based on the config given in the auction contract and
         // sends them to the auction contract,
-        __ERC20_init("SimpleBond", "LUG");
+        __ERC20_init(_name, _symbol);
         __ERC20Burnable_init();
         __Ownable_init();
 

--- a/test/Broker.spec.ts
+++ b/test/Broker.spec.ts
@@ -36,6 +36,8 @@ describe("Broker", async () => {
     const { borrowingToken } = await borrowingTokenFixture();
     const bond = await getBondContract(
       broker.createBond(
+        "SimpleBond",
+        "LUG",
         issuerSigner.address,
         maturityDate,
         maxBondSupply,

--- a/test/SimpleBond.spec.ts
+++ b/test/SimpleBond.spec.ts
@@ -56,6 +56,8 @@ describe("SimpleBond", async () => {
 
     const bond = await getBondContract(
       factory.createBond(
+        "SimpleBond",
+        "LUG",
         owner.address,
         issuer.address,
         BondConfig.maturityDate,
@@ -70,6 +72,8 @@ describe("SimpleBond", async () => {
 
     const convertibleBond = await getBondContract(
       factory.createBond(
+        "SimpleBond",
+        "LUG",
         owner.address,
         issuer.address,
         BondConfig.maturityDate,


### PR DESCRIPTION
Closes #64 

@Namaskar-1F64F did you find a good article that covers when to use `memory`, `calldata`, `storage`, or nothing? 

I used `memory` for `name` and `symbol` because that's what balancer used in their [factory](https://github.com/balancer-labs/balancer-v2-monorepo/blob/538e7ff6dd7c0492822a55fe430a4ad9038f9039/pkg/pool-weighted/contracts/WeightedPoolFactory.sol#L34) 

I read https://stackoverflow.com/questions/33839154/in-ethereum-solidity-what-is-the-purpose-of-the-memory-keyword but am still quite confused 