### PR TITLE
Support Single Collateral

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,49 +9,66 @@
  <td><a href="https://twitter.com/porterfinance_">twitter</a></td>
 </table>
 
-# V1 
+# V1
 
-Smart Contracts powering the Porter protocol. 
+Smart Contracts powering the Porter protocol.
 
 ## Development
 
-For local development there are environment variables necessary to enable some hardhat plugins. 
+For local development there are environment variables necessary to enable some hardhat plugins.
+
 ### Deployment
 
 Using hardhat-deploy all of the scripts in the `./deploy` folder are run.
 
 Deploying to rinkeby
+
 ```
 npx hardhat deploy --network rinkeby
 ```
+
 Deploying privately on Tenderly requires a log in to the tenderly-cli and ensure the `tenderly.push` command is used in the deploy scripts.
+
 ```
 npx hardhat deploy
 ```
+
 ### Verification
+
 Verify deployed contracts with `hardhat-etherscan`.
+
 ```
 npx hardhat verify <address>
 ```
+
 Verify contract with Tenderly also requires a log in to the tenderly-cli and ensure the `tenderly.verify` command is used in the deploy scripts.
+
 ```
 npx hardhat deploy
 ```
+
 ### Testing
+
 Running the test suite
+
 ```
 npx hardhat test
 ```
+
 Fork testing requires first running the mainnet-fork
+
 ```
 npx hardhat node
 ```
+
 and making the target for testing the local node
+
 ```
 npx hardhat test --network localhost
 ```
 
 ### Other useful commands
+
 ```shell
 npx hardhat help
 npx hardhat compile # create contract artifacts

--- a/contracts/BondFactoryClone.sol
+++ b/contracts/BondFactoryClone.sol
@@ -53,10 +53,10 @@ contract BondFactoryClone is AccessControl {
     /// @param _symbol Ticker symbol for the bond
     /// @param _owner Owner of the bond
     /// @param _maturityDate Timestamp of when the bond matures
-    /// @param _collateralTokens Addresses of the collateral to use for the bond
-    /// @param _backingRatios Ratios of bond:token to be used
+    /// @param _collateralToken Address of the collateral to use for the bond
+    /// @param _backingRatio Ratio of bond:token to be used
     /// @param _borrowingToken Address of the token being borrowed by the issuer of the bond
-    /// @param _convertibilityRatios Ratios of bond:token that the bond can be converted into
+    /// @param _convertibilityRatio Ratio of bond:token that the bond can be converted into
     /// @dev this uses a clone to save on deployment costs https://github.com/porter-finance/v1-core/issues/15
     /// This adds a slight overhead everytime users interact with the bonds - but saves 10x the gas during deployment
     function createBond(
@@ -65,9 +65,9 @@ contract BondFactoryClone is AccessControl {
         address _owner,
         uint256 _maturityDate,
         address _borrowingToken,
-        address[] memory _collateralTokens,
-        uint256[] memory _backingRatios,
-        uint256[] memory _convertibilityRatios
+        address _collateralToken,
+        uint256 _backingRatio,
+        uint256 _convertibilityRatio
     ) external onlyIssuer returns (address clone) {
         clone = Clones.clone(tokenImplementation);
         SimpleBond(clone).initialize(
@@ -76,9 +76,9 @@ contract BondFactoryClone is AccessControl {
             _owner,
             _maturityDate,
             _borrowingToken,
-            _collateralTokens,
-            _backingRatios,
-            _convertibilityRatios
+            _collateralToken,
+            _backingRatio,
+            _convertibilityRatio
         );
         emit BondCreated(clone);
     }

--- a/test/BondFactory.spec.ts
+++ b/test/BondFactory.spec.ts
@@ -1,8 +1,9 @@
-import { BigNumber, BigNumberish, utils } from "ethers";
+import { BigNumber, utils } from "ethers";
 import { expect } from "chai";
 import { BondFactoryClone } from "../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { bondFactoryFixture } from "./shared/fixtures";
+import { BondConfigType } from "./interfaces";
 
 const { ethers } = require("hardhat");
 
@@ -16,17 +17,11 @@ const TEST_ADDRESSES: [string, string] = [
   "0x2000000000000000000000000000000000000000",
 ];
 
-const BondConfig: {
-  targetBondSupply: BigNumber;
-  collateralTokens: string[];
-  collateralRatios: BigNumber[];
-  convertibilityRatios: BigNumber[];
-  maturityDate: BigNumberish;
-} = {
+const BondConfig: BondConfigType = {
   targetBondSupply: utils.parseUnits("50000000", 18), // 50 million bonds
-  collateralTokens: [""],
-  collateralRatios: [BigNumber.from(0)],
-  convertibilityRatios: [BigNumber.from(0)],
+  collateralToken: "",
+  collateralRatio: BigNumber.from(0),
+  convertibilityRatio: BigNumber.from(0),
   maturityDate,
 };
 
@@ -43,24 +38,18 @@ describe("BondFactory", async () => {
   });
 
   async function createBond(factory: BondFactoryClone) {
-    BondConfig.collateralTokens = [TEST_ADDRESSES[0], TEST_ADDRESSES[1]];
-    BondConfig.collateralRatios = [
-      utils.parseUnits("0.5", 18),
-      utils.parseUnits("0.25", 18),
-    ];
-    BondConfig.convertibilityRatios = [
-      utils.parseUnits("0.5", 18),
-      utils.parseUnits("0.25", 18),
-    ];
+    BondConfig.collateralToken = TEST_ADDRESSES[0];
+    BondConfig.collateralRatio = utils.parseUnits("0.5", 18);
+    BondConfig.convertibilityRatio = utils.parseUnits("0.5", 18);
     return factory.createBond(
       "SimpleBond",
       "LUG",
       owner.address,
       BondConfig.maturityDate,
       TEST_ADDRESSES[0],
-      BondConfig.collateralTokens,
-      BondConfig.collateralRatios,
-      BondConfig.convertibilityRatios
+      BondConfig.collateralToken,
+      BondConfig.collateralRatio,
+      BondConfig.convertibilityRatio
     );
   }
 

--- a/test/interfaces.ts
+++ b/test/interfaces.ts
@@ -1,0 +1,9 @@
+import { BigNumber, BigNumberish } from "ethers";
+
+export type BondConfigType = {
+  targetBondSupply: BigNumber;
+  collateralToken: string;
+  collateralRatio: BigNumber;
+  convertibilityRatio: BigNumber;
+  maturityDate: BigNumberish;
+};


### PR DESCRIPTION
This PR removes the 's' on collateralToken, backingRatio, and convertibilityRatio.  This simplifies the functions that were previously looping over the collateral tokens as there is only one token.

closes #87 