### PR TITLE
remove loops and extract functionality to utility

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -476,9 +476,7 @@ contract Bond is
                 collateralTokensRequired
                 ? convertibleTokensRequired
                 : collateralTokensRequired;
-        } else if (isMature()) {
-            // this seems wrong and using !isMature does not cause tests to fail
-            // # TODO investigate and add tests
+        } else if (!isMature()) {
             totalRequiredCollateral = convertibleTokensRequired;
         } else {
             // @audit-info redundant but explicit

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -61,6 +61,13 @@ export const getTargetCollateral = (bondConfig: BondConfigType): BigNumber => {
   return targetBondSupply.mul(collateralRatio).div(ONE);
 };
 
+export const getTargetConvertibleCollateral = (
+  bondConfig: BondConfigType
+): BigNumber => {
+  const { targetBondSupply, convertibleRatio } = bondConfig;
+  return targetBondSupply.mul(convertibleRatio).div(ONE);
+};
+
 export const getTargetPayment = (
   bondConfig: BondConfigType,
   decimals: BigNumberish


### PR DESCRIPTION
I had moved the loops (`forEach`)es into the `it` statements when moving towards the dynamic configurations, but now realize that was a mistake because the state is not reset by the `beforeEach` while in the same `it` block. This separates all the loops into their own `it` blocks and moves some of the repeated functionality into the `utilities` file.