### PR TITLE
remove unnecessary sweep guard

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -408,7 +408,6 @@ contract Bond is
     {
         if (
             address(token) == paymentToken ||
-            address(token) == address(this) ||
             address(token) == collateralToken
         ) {
             revert SweepDisallowedForToken();

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -1752,9 +1752,6 @@ describe("Bond", () => {
           });
 
           it("should disallow removal of tokens: collateral, payment, or itself", async () => {
-            await expect(bond.sweep(bond.address)).to.be.revertedWith(
-              "SweepDisallowedForToken"
-            );
             await expect(bond.sweep(paymentToken.address)).to.be.revertedWith(
               "SweepDisallowedForToken"
             );


### PR DESCRIPTION
Can we remove this? As far as I understand, the contract should never have custody of bond tokens. If a user accidentally sends the bond tokens to the bond contract I believe they should be able to be retrieved using sweep. 

LMK if I'm missing something @Namaskar-1F64F 