### PR TITLE
Fix NatSpec

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -185,6 +185,7 @@ contract Bond is
         @param _collateralToken the ERC20 token address for the bond
         @param _collateralRatio the amount of tokens per bond needed as collateral
         @param _convertibleRatio the amount of tokens per bond a convertible bond can be converted for
+        @param maxSupply the amount of bonds to mint initially
     */
     function initialize(
         string memory bondName,
@@ -380,7 +381,7 @@ contract Bond is
                 to cover convertibleRatio = 0
             bond IS paid AND NOT mature (PaidEarly)
                 to cover collateralRatio = 0 (bonds need not be backed by collateral)
-                to cover convertibleRatio = total supply * convertibleRatio ratio
+                to cover convertibleRatio = total supply * convertibleRatio
 
             bond is NOT paid AND NOT mature (Active)
                 to cover collateralRatio = total uncovered supply * collateralRatio
@@ -505,6 +506,7 @@ contract Bond is
 
     /**
         @notice the amount of payment tokens required to fully pay the contract
+        @return the amount of payment tokens
     */
     function amountOwed() external view returns (uint256) {
         if (totalSupply() <= paymentBalance()) {

--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -121,6 +121,7 @@ contract BondFactory is AccessControl {
         @param bonds number of bonds to mint
         @dev This uses a clone to save on deployment costs which adds a slight overhead
             everytime users interact with the bonds - but saves on gas during deployment
+        @return clone the address of the newly created bond-clone
     */
     function createBond(
         string memory name,


### PR DESCRIPTION
closes #203 

initialize function’s NatSpec comments miss describing _maxSupply parameter.

_upscale function’s NatSpec comments miss describing parameter and return values.
_this was removed_

Functions createBond, amountOwed, _safeTransferIn miss describing return values
_safetransferin was removed_

The ordering and definition of collateralRatio and convertibleRatio in Natspeccomments of the createBond function should be fixed.
_this was removed_

Comment states that convertibleRatio depends on the collateralRatio if the bond is paid but not mature yet which is different from implementation where convertibleRatio is what is used.