### PR TITLE
Make comments short-er

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -49,14 +49,14 @@ contract Bond is
     uint256 public convertibleRatio;
 
     /**
-        @notice This role permits the withdraw of collateral from the contract
+        @notice This role permits the withdraw of collateral from the contract.
         @dev This role is assigned to the owner upon bond creation who can also
             assign this role to other addresses to enable their withdraw.
             
     */
     bytes32 public constant WITHDRAW_ROLE = keccak256("WITHDRAW_ROLE");
 
-    /// @dev Used to confirm the bond has not yet matured
+    /// @dev Used to confirm the bond has not yet matured.
     modifier beforeMaturity() {
         if (isMature()) {
             revert BondPastMaturity();
@@ -64,7 +64,7 @@ contract Bond is
         _;
     }
 
-    /// @dev Used to confirm that the bon is either mature or has been paid
+    /// @dev Used to confirm that the bon is either mature or has been paid.
     modifier afterMaturityOrPaid() {
         if (!isMature() && !isFullyPaid()) {
             revert BondNotYetMaturedOrPaid();

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -16,10 +16,12 @@ import {FixedPointMathLib} from "./utils/FixedPointMathLib.sol";
     @title Bond
     @author Porter Finance
     @notice A custom ERC20 token that can be used to issue bonds.
-    @notice The contract handles issuance, payment, conversion, and redemption of bonds.
-    @dev External calls to tokens used for collateral and payment are used throughout to transfer and check balances
-        there is risk that these tokens are malicious and each one should be carefully inspected before being trusted. 
-    @dev does not inherit from ERC20Upgradeable or Initializable since ERC20BurnableUpgradeable inherits from them
+    @notice The contract handles issuance, payment, conversion, and redemption.
+    @dev External calls to tokens used for collateral and payment are used
+        throughout to transfer and check balances. There is risk that these
+        are non-standard and should be carefully inspected before being trusted. 
+    @dev Does not inherit from ERC20Upgradeable or Initializable since
+        ERC20BurnableUpgradeable inherits from them.
 */
 contract Bond is
     IBond,
@@ -47,13 +49,14 @@ contract Bond is
     uint256 public convertibleRatio;
 
     /**
-        @notice this role permits the withdraw of collateral from the contract
-        @dev this is assigned to owner in `initialize`
-            the owner can assign other addresses with this role to enable their withdraw
+        @notice This role permits the withdraw of collateral from the contract
+        @dev This role is assigned to the owner upon bond creation who can also
+            assign this role to other addresses to enable their withdraw.
+            
     */
     bytes32 public constant WITHDRAW_ROLE = keccak256("WITHDRAW_ROLE");
 
-    /// @dev used to confirm the bond has not yet matured
+    /// @dev Used to confirm the bond has not yet matured
     modifier beforeMaturity() {
         if (isMature()) {
             revert BondPastMaturity();
@@ -61,7 +64,7 @@ contract Bond is
         _;
     }
 
-    /// @dev used to confirm that the maturity date has passed or the bond has been repaid
+    /// @dev Used to confirm that the bon is either mature or has been paid
     modifier afterMaturityOrPaid() {
         if (!isMature() && !isFullyPaid()) {
             revert BondNotYetMaturedOrPaid();
@@ -105,10 +108,9 @@ contract Bond is
 
         burn(bonds);
 
-        // saves an extra SLOAD
+        // Saves an extra SLOAD
         address collateral = collateralToken;
 
-        //  Reentrancy possibility: the bonds are already burnt - if there weren't enough bonds to burn, an error is thrown
         IERC20Metadata(collateral).safeTransfer(
             _msgSender(),
             convertibleTokensToSend
@@ -118,14 +120,14 @@ contract Bond is
     }
 
     /// @inheritdoc IBond
-    function withdrawCollateral()
+    function withdrawExcessCollateral()
         external
         nonReentrant
         onlyRole(WITHDRAW_ROLE)
     {
         uint256 collateralToSend = previewWithdraw();
 
-        // saves an extra SLOAD
+        // Saves an extra SLOAD
         address collateral = collateralToken;
 
         IERC20Metadata(collateral).safeTransfer(_msgSender(), collateralToSend);
@@ -167,11 +169,10 @@ contract Bond is
 
         burn(bonds);
 
-        // saves an extra SLOAD
+        // Saves an extra SLOAD
         address payment = paymentToken;
         address collateral = collateralToken;
 
-        // reentrancy possibility: the bonds are burnt here already - if there weren't enough bonds to burn, an error is thrown
         if (paymentTokensToSend != 0) {
             IERC20Metadata(payment).safeTransfer(
                 _msgSender(),
@@ -179,7 +180,6 @@ contract Bond is
             );
         }
         if (collateralTokensToSend != 0) {
-            // reentrancy possibility: the bonds are burnt here already - if there weren't enough bonds to burn, an error is thrown
             IERC20Metadata(collateral).safeTransfer(
                 _msgSender(),
                 collateralTokensToSend
@@ -291,7 +291,7 @@ contract Bond is
         if (overpayment <= 0) {
             revert NoPaymentToWithdraw();
         }
-        // saves an extra SLOAD
+        // Saves an extra SLOAD
         address payment = paymentToken;
 
         IERC20Metadata(payment).safeTransfer(_msgSender(), overpayment);

--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -15,15 +15,15 @@ import "./Bond.sol";
 /** 
     @title Bond Factory
     @author Porter Finance
-    @notice This factory contract issues new bond contracts
-    @dev This uses a cloneFactory to save on gas costs during deployment
-        see OpenZeppelin's "Clones" proxy
+    @notice This factory contract issues new bond contracts.
+    @dev This uses a cloneFactory to save on gas costs during deployment.
+        See OpenZeppelin's "Clones" proxy
 */
 contract BondFactory is IBondFactory, AccessControl {
     using SafeERC20 for IERC20Metadata;
     using FixedPointMathLib for uint256;
 
-    /// @notice the role required to issue bonds
+    /// @notice The role required to issue bonds
     bytes32 public constant ISSUER_ROLE = keccak256("ISSUER_ROLE");
 
     /// @inheritdoc IBondFactory
@@ -35,7 +35,10 @@ contract BondFactory is IBondFactory, AccessControl {
     /// @inheritdoc IBondFactory
     bool public isAllowListEnabled = true;
 
-    /// @dev If allow list is enabled, only allow listed issuers are able to call functions
+    /**
+        @dev If allow list is enabled, only allow-listed issuers are
+            able to call functions
+    */
     modifier onlyIssuer() {
         if (isAllowListEnabled) {
             _checkRole(ISSUER_ROLE, _msgSender());
@@ -45,9 +48,9 @@ contract BondFactory is IBondFactory, AccessControl {
 
     constructor() {
         tokenImplementation = address(new Bond());
-        // this grants the user deploying this contract the DEFAULT_ADMIN_ROLE
+        // This grants the user deploying this contract the DEFAULT_ADMIN_ROLE
         // which gives them the ability to call grantRole to grant access to
-        // the ISSUER_ROLE
+        // the ISSUER_ROLE.
         _grantRole(DEFAULT_ADMIN_ROLE, _msgSender());
     }
 
@@ -141,8 +144,8 @@ contract BondFactory is IBondFactory, AccessControl {
         uint256 amountDeposited = IERC20Metadata(collateralToken).balanceOf(
             clone
         );
-        // greater than instead of != for the case where the collateral is sent to the
-        // clone address before creation
+        // Greater than instead of != for the case where the collateralToken
+        // is sent to the clone address before creation.
         if (collateralToDeposit > amountDeposited) {
             revert InvalidDeposit();
         }

--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -17,13 +17,13 @@ import "./Bond.sol";
     @author Porter Finance
     @notice This factory contract issues new bond contracts.
     @dev This uses a cloneFactory to save on gas costs during deployment.
-        See OpenZeppelin's "Clones" proxy
+        See OpenZeppelin's "Clones" proxy.
 */
 contract BondFactory is IBondFactory, AccessControl {
     using SafeERC20 for IERC20Metadata;
     using FixedPointMathLib for uint256;
 
-    /// @notice The role required to issue bonds
+    /// @notice The role required to issue bonds.
     bytes32 public constant ISSUER_ROLE = keccak256("ISSUER_ROLE");
 
     /// @inheritdoc IBondFactory
@@ -37,7 +37,7 @@ contract BondFactory is IBondFactory, AccessControl {
 
     /**
         @dev If allow list is enabled, only allow-listed issuers are
-            able to call functions
+            able to call functions.
     */
     modifier onlyIssuer() {
         if (isAllowListEnabled) {

--- a/contracts/echidna/TestBond.sol
+++ b/contracts/echidna/TestBond.sol
@@ -111,8 +111,10 @@ contract TestBond {
         checkGeneralInvariants();
     }
 
-    function withdrawCollateral() public {
-        try bond.withdrawCollateral() {} catch Error(string memory reason) {
+    function withdrawExcessCollateral() public {
+        try bond.withdrawExcessCollateral() {} catch Error(
+            string memory reason
+        ) {
             emit AssertionFailed(reason);
         }
         checkGeneralInvariants();

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -2,33 +2,32 @@
 pragma solidity 0.8.9;
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import {Bond} from "../Bond.sol";
 
 interface IBond {
-    /// @notice operation restricted because the bond has matured
+    /// @notice Operation restricted because the bond has matured.
     error BondPastMaturity();
 
-    /// @notice operation restricted because the bond is not yet matured or paid
+    /// @notice Operation restricted because the bond has not matured or paid.
     error BondNotYetMaturedOrPaid();
 
-    /// @notice attempted to pay after payment was met
+    /// @notice Attempted to pay after payment was met.
     error PaymentMet();
 
-    /// @notice attempted to sweep a token used in the contract
+    /// @notice Attempted to sweep a token used in the contract.
     error SweepDisallowedForToken();
 
-    /// @notice attempted to perform an action that would do nothing
+    /// @notice Attempted to perform an action that would do nothing.
     error ZeroAmount();
 
-    /// @notice There is no excess payment in the contract that is avaliable to withdraw
+    /// @notice Attempted to withdraw with no excess payment in the contract.
     error NoPaymentToWithdraw();
 
     /**
-        @notice emitted when bond tokens are converted by a borrower
-        @param from the address converting their tokens
-        @param collateralToken the address of the collateral received
-        @param amountOfBondsConverted the number of burnt bonds
-        @param amountOfCollateralTokens the number of collateral tokens received
+        @notice Emitted when Bond tokens are converted by a borrower.
+        @param from The address converting their tokens.
+        @param collateralToken The address of the collateralToken.
+        @param amountOfBondsConverted The number of burnt Bonds.
+        @param amountOfCollateralTokens The number of collateralTokens received.
     */
     event Convert(
         address indexed from,
@@ -38,10 +37,10 @@ interface IBond {
     );
 
     /**
-        @notice emitted when collateral is withdrawn
-        @param from the address withdrawing collateral
-        @param token the address of the collateral token
-        @param amount the number of the tokens withdrawn
+        @notice Emitted when collateral is withdrawn.
+        @param from The address withdrawing the collateral.
+        @param token The address of the collateralToken.
+        @param amount The number of collateralTokens withdrawn.
     */
     event CollateralWithdraw(
         address indexed from,
@@ -50,20 +49,21 @@ interface IBond {
     );
 
     /**
-        @notice emitted when a portion of the bond's principal is paid
-        @param from the address depositing payment
-        @param amount Amount paid. The amount could be incorrect if the payment token takes a fee on transfer. 
+        @notice Emitted when a portion of the Bond's principal is paid.
+        @param from The address depositing payment.
+        @param amount Amount paid.
+        @dev The amount could be incorrect if the token takes a fee on transfer. 
     */
     event Payment(address indexed from, uint256 amount);
 
     /**
-        @notice emitted when a bond is redeemed
-        @param from the bond holder whose bonds are burnt
-        @param paymentToken the address of the payment token
-        @param collateralToken the address of the collateral token
-        @param amountOfBondsRedeemed the amount of bonds burned for redemption
-        @param amountOfPaymentTokensReceived the amount of payment tokens
-        @param amountOfCollateralTokens the amount of collateral tokens
+        @notice Emitted when a Bond is redeemed.
+        @param from The Bond holder whose Bonds are burnt.
+        @param paymentToken The address of the paymentToken.
+        @param collateralToken The address of the collateralToken.
+        @param amountOfBondsRedeemed The amount of Bonds burned for redemption.
+        @param amountOfPaymentTokensReceived The amount of paymentTokens.
+        @param amountOfCollateralTokens The amount of collateralTokens.
     */
     event Redeem(
         address indexed from,
@@ -75,10 +75,10 @@ interface IBond {
     );
 
     /**
-        @notice emitted when payment over the required payment amount is withdrawn
-        @param from the caller withdrawing the excessPaymentAmount
-        @param token the paymentToken being withdrawn
-        @param amount the amount of paymentToken withdrawn
+        @notice Emitted when payment over the required amount is withdrawn.
+        @param from The caller withdrawing the excess payment amount.
+        @param token The paymentToken being withdrawn.
+        @param amount The amount of paymentToken withdrawn.
     */
     event ExcessPaymentWithdraw(
         address indexed from,
@@ -87,70 +87,83 @@ interface IBond {
     );
 
     /**
-        @notice emitted when payment over the required payment amount is withdrawn
-        @param from the caller who the tokens were sent to 
-        @param token the token that was swept 
-        @param amount the amount that was swept 
+        @notice Emitted when a token is swept by the contract owner.
+        @param from The owner's address.
+        @param token The token that was swept.
+        @param amount The amount that was swept.
     */
     event TokenSweep(address from, IERC20Metadata token, uint256 amount);
 
     /**
-        @notice gets the amount that was overpaid and can be withdrawn 
-        @return overpayment amount that was overpaid 
+        @notice The amount that was overpaid and can be withdrawn.
+        @return overpayment Amount that was overpaid.
     */
     function amountOverPaid() external view returns (uint256 overpayment);
 
     /**
-        @notice the amount of payment tokens required to fully pay the contract
-        @return the amount of payment tokens
+        @notice The amount of paymentTokens required to fully pay the contract.
+        @return The amount of paymentTokens.
     */
     function amountOwed() external view returns (uint256);
 
     /**
-        @notice gets the external balance of the ERC20 collateral token
-        @return the amount of collateralTokens in the contract
+        @notice The external balance of the ERC20 collateral token.
+        @return The amount of collateralTokens in the contract.
     */
     function collateralBalance() external view returns (uint256);
 
     /**
-        @notice the ratio of collateral tokens per bond with
-        @dev this amount is expressed as a deviation from 1-to-1 (equal to 1e18)
-            number of collateral tokens backing one bond
+        @notice The ratio of collateralTokens per Bond.
+        @dev This amount is calculated as a deviation from 1-to-1 multiplied by
+            the decimals of the collateralToken. See BondFactory's `CreateBond`.
+        @return The number of tokens backing a Bond.
     */
     function collateralRatio() external view returns (uint256);
 
-    /// @notice the address of the ERC20 token used as collateral backing the bond
+    /**
+        @notice The ERC20 token used as collateral backing the bond.
+        @return The ERC20 token's address
+    */
     function collateralToken() external view returns (address);
 
     /**
-        @notice Bond holder can convert their bond to underlying collateral at the convertible ratio
-            The bond must be convertible and not past maturity
-        @param bonds the number of bonds which will be burnt and converted into the collateral at the convertibleRatio
+        @notice For convertible Bonds (ones with a convertibilityRatio > 0),
+        the Bond holder may convert their bond to underlying collateral at the
+        convertibleRatio. The bond must also have not past maturity
+        for this to be possible.
+        @param bonds The number of bonds which will be burnt and converted
+            into the collateral at the convertibleRatio.
     */
     function convert(uint256 bonds) external;
 
     /**
-        @notice the ratio of ERC20 tokens the bonds will convert into
-        @dev this amount is expressed as a deviation from 1-to-1 (equal to 1e18)
-             if this ratio is 0, the bond is not convertible.
-             after maturity, the bond is not convertible
-        @dev number of tokens one bond converts into
+        @notice The ratio of convertibleTokens the bonds will convert into.
+        @dev This amount is calculated as a deviation from 1-to-1 multiplied by
+            the decimals of the collateralToken. See BondFactory's `CreateBond`.
+            The "convertibleTokens" are a subset of the collateralTokens, based
+            on this ratio. If this ratio is 0, the bond is not convertible.
+        @dev Number of tokens a Bond converts into.
     */
     function convertibleRatio() external view returns (uint256);
 
     /**
-        @notice this function is called one time during initial bond creation and sets up the configuration for the bond
-        @dev New bond contract deployed via clone
-        @dev Not calling __AccessControl_init or __ERC20Burnable_init here because they currently generate an empty function 
-        @param bondName passed into the ERC20 token
-        @param bondSymbol passed into the ERC20 token
-        @param owner ownership of this contract transferred to this address
-        @param _maturityDate the timestamp at which the bond will mature
-        @param _paymentToken the ERC20 token address the bond will be redeemable for at maturity
-        @param _collateralToken the ERC20 token address for the bond
-        @param _collateralRatio the amount of tokens per bond needed as collateral
-        @param _convertibleRatio the amount of tokens per bond a convertible bond can be converted for
-        @param maxSupply the amount of bonds to mint initially
+        @notice This one-time setup initiated by the BondFactory initializes the
+            Bond with the given configuration.
+        @dev New Bond contract deployed via clone. See `BondFactory`.
+        @dev Not calling __AccessControl_init or __ERC20Burnable_init here since
+            they currently generate an empty function.
+        @param bondName Passed into the ERC20 token to define the name.
+        @param bondSymbol Passed into the ERC20 token to define the symbol.
+        @param owner Ownership of the created Bond is transferred to this
+            address by way of DEFAULT_ADMIN_ROLE. The ability to withdraw is 
+            given by WITHDRAW_ROLE, and tokens are minted to this address.
+        @param _maturityDate The timestamp at which the Bond will mature.
+        @param _paymentToken The ERC20 token address the Bond is redeemable for.
+        @param _collateralToken The ERC20 token address the Bond is backed by.
+        @param _collateralRatio The amount of collateral tokens per bond.
+        @param _convertibleRatio The amount of convertible tokens per bond.
+        @param maxSupply The amount of Bonds given to the owner during the one-
+            time mint during this initialization.
     */
     function initialize(
         string memory bondName,
@@ -165,50 +178,49 @@ interface IBond {
     ) external;
 
     /**
-        @notice checks if the balance of payment token covers the bond supply
-        @dev upscaling the token amount as there could be differing decimals
-        @return whether or not the bond is fully paid
+        @notice Checks if the balance of payment token covers the Bond supply.
+        @return Whether or not the Bond is fully paid.
     */
     function isFullyPaid() external view returns (bool);
 
     /**
-        @notice checks if the maturity date has passed (including current block timestamp)
-        @return whether or not the bond has reached the maturity date
+        @notice Checks if the maturity date has passed.
+        @return Whether or not the Bond has reached the maturity date.
     */
     function isMature() external view returns (bool);
 
     /**
-        @notice A date in the future set at bond creation at which the bond will mature.
-            Before this date, a bond token can be converted if convertible, but cannot be redeemed.
-            Before this date, a bond token can be redeemed if the bond has been fully paid
-            After this date, a bond token can be redeemed for the payment token, but cannot be converted.
+        @notice A date set at Bond creation when the Bond will mature.
+        @return The maturity date timestamp.
     */
     function maturityDate() external view returns (uint256);
 
     /**
-        @notice allows the issuer to pay the bond by transferring payment token
-        @dev emits Payment event
-        @param amount the number of payment tokens to pay
+        @notice Allows the issuer to pay the bond by depositing payment token.
+        @dev Emits Payment event.
+        @param amount The number of paymentTokens to deposit.
     */
     function pay(uint256 amount) external;
 
     /**
-        @notice gets the external balance of the ERC20 payment token
-        @return the amount of paymentTokens in the contract
+        @notice Gets the external balance of the ERC20 payment token.
+        @return The number of paymentTokens in the contract.
     */
     function paymentBalance() external view returns (uint256);
 
     /**
-        @notice The address of the ERC20 token this bond will be redeemable for at maturity
-            which is paid by the borrower to unlock their collateral
+        @notice This is the token the borrower deposits into the contract and
+            what the Bond holders will receive when redeemed.
+        @return The address of the token.
     */
     function paymentToken() external view returns (address);
 
     /**
-      @notice the amount of collateral the given bonds would convert into if able
-      @dev this function rounds down the number of returned collateral
-      @param bonds the amount of bonds that would be burnt to convert into collateral
-      @return amount of collateral received
+        @notice Before maturity, if the given bonds are converted, this would be
+            the number of collateralTokens received.
+        @dev This function rounds down the number of returned collateral.
+        @param bonds The number of Bonds burnt and converted into collateral.
+        @return The number of collateralTokens the Bonds will be converted into.
     */
     function previewConvertBeforeMaturity(uint256 bonds)
         external
@@ -216,11 +228,11 @@ interface IBond {
         returns (uint256);
 
     /**
-        @notice the amount of collateral and payment tokens
-            the bonds would redeem for at maturity
-        @param bonds the amount of bonds to burn and redeem for tokens
-        @return the amount of payment tokens to receive
-        @return the amount of collateral tokens to receive
+        @notice At maturity, if the given bonds are redeemed, this would be the
+            amount of collateralTokens and paymentTokens received.
+        @param bonds The number of Bonds to burn and redeem for tokens.
+        @return The number of paymentTokens to receive.
+        @return The number of collateralTokens to receive.
     */
     function previewRedeemAtMaturity(uint256 bonds)
         external
@@ -228,58 +240,74 @@ interface IBond {
         returns (uint256, uint256);
 
     /** 
-        @notice the amount of collateral that the issuer would be able to 
-            withdraw from the contract
-        @dev this function calculates the amount of collateral tokens that are able to be withdrawn by the issuer.
-            The amount of tokens can increase by bonds being burnt and converted as well as payment made.
-            Each bond is covered by a certain amount of collateral to fulfill collateralRatio and convertibleRatio.
-            For convertible bonds, the totalSupply of bonds must be covered by the convertibleRatio.
-            That means even if all of the bonds were covered by payment, there must still be enough collateral
-            in the contract to cover the outstanding bonds convertible until the maturity date -
-            at which point all collateral will be able to be withdrawn.
+        @notice The amount of collateral that the issuer would be able to 
+            withdraw from the contract.
+        @dev This function calculates the amount of collateralTokens that are
+            able to be withdrawn by the issuer. The amount of tokens can
+            increase when Bonds are burnt and converted as well when payment is
+            made. Each Bond is covered by a certain amount of collateral to
+            the collateralRatio. In addition to covering the collateralRatio,
+            convertible Bonds (ones with a convertibleRatio greater than 0) must
+            have enough convertibleTokens in the contract to the totalSupply of
+            Bonds as well. That means even if all of the Bonds were covered by
+            payment, there must still be enough collateral in the contract to
+            cover the portion of collateral that would be required to convert
+            the totalSupply of outstanding Bonds. At the maturity date, however,
+            all collateral will be able to be withdrawn as the Bond would no
+            longer be convertible.
 
-        There are the following scenarios:
-        "total uncovered supply" is the tokens that are not covered by the amount repaid.
-
+            There are the following scenarios:
             bond IS paid AND mature (Paid)
-                to cover collateralRatio = 0
-                to cover convertibleRatio = 0
+                to cover collateralRatio: 0
+                to cover convertibleRatio: 0
+
             bond IS paid AND NOT mature (PaidEarly)
-                to cover collateralRatio = 0 (bonds need not be backed by collateral)
-                to cover convertibleRatio = total supply * convertibleRatio
+                to cover collateralRatio: 0
+                to cover convertibleRatio: totalSupply * convertibleRatio
+
+            * totalUncoveredSupply: Bonds not covered by paymentTokens *
 
             bond is NOT paid AND NOT mature (Active)
-                to cover collateralRatio = total uncovered supply * collateralRatio
-                to cover convertibleRatio = total supply * convertibleRatio
+                to cover collateralRatio: totalUncoveredSupply * collateralRatio
+                to cover convertibleRatio: totalSupply * convertibleRatio
+
             bond is NOT paid AND mature (Defaulted)
-                to cover collateralRatio = total uncovered supply * collateralRatio
-                to cover convertibleRatio = 0 (bonds cannot be converted)
-            All outstanding bonds must be covered by the convertibleRatio
-        @return the amount of collateral received
+                to cover collateralRatio: totalUncoveredSupply * collateralRatio
+                to cover convertibleRatio: 0
+        @return The number of collateralTokens received.
      */
     function previewWithdraw() external view returns (uint256);
 
     /**
-        @notice this function burns bonds in return for the token borrowed against the bond
-        @param bonds the amount of bonds to redeem and burn
+        @notice The Bond holder can burn Bonds in return for their portion of
+        paymentTokens and collateralTokens backing the Bonds. These portions of
+        tokens depends on the number of paymentTokens deposited. When the Bond
+        is fully paid, redemption will result in all paymentTokens. If the Bond
+        has reached maturity without being fully paid, a portion of the
+        collateralTokens will be availalbe.
+        @dev Emits Redeem event.
+        @param bonds The number of bonds to redeem and burn
     */
     function redeem(uint256 bonds) external;
 
     /**
-        @notice sends tokens to the issuer that were sent to this contract
-        @dev collateral, payment, and the bond itself cannot be swept
-        @param token send the entire token balance of this address to the owner
+        @notice Sends tokens to the owner that are in this contract.
+        @dev The collateralToken and paymentToken, cannot be swept.
+        @param token The ERC20 token to sweep and send to the owner.
     */
     function sweep(IERC20Metadata token) external;
 
     /**
-        @notice Withdraw collateral from bond contract
-            the amount of collateral available to be withdrawn depends on the collateralRatio and the convertibleRatio
+        @notice A caller with the WITHDRAW_ROLE may withdraw excess collateral
+            from bond contract. The number of collateralTokens remaining in the
+            contract must be enough to cover the total supply of Bonds in
+            accordance to both the collateralRatio and convertibleRatio.
     */
-    function withdrawCollateral() external;
+    function withdrawExcessCollateral() external;
 
     /**
-        @notice withdraws any overpaid payment token 
+        @notice A caller with the WITHDRAW_ROLE can withdraw any overpaid
+            payment token in the contract.
     */
     function withdrawExcessPayment() external;
 }

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -122,7 +122,7 @@ interface IBond {
 
     /**
         @notice The ERC20 token used as collateral backing the bond.
-        @return The ERC20 token's address
+        @return The ERC20 token's address.
     */
     function collateralToken() external view returns (address);
 
@@ -286,7 +286,7 @@ interface IBond {
         has reached maturity without being fully paid, a portion of the
         collateralTokens will be availalbe.
         @dev Emits Redeem event.
-        @param bonds The number of bonds to redeem and burn
+        @param bonds The number of bonds to redeem and burn.
     */
     function redeem(uint256 bonds) external;
 

--- a/contracts/interfaces/IBondFactory.sol
+++ b/contracts/interfaces/IBondFactory.sol
@@ -3,15 +3,27 @@ pragma solidity 0.8.9;
 
 interface IBondFactory {
     /**
-        @notice Emitted when the allow list is toggled on or off
-        @param isAllowListEnabled the new state of the allow list
+        @notice Emitted when the allow list is toggled on or off.
+        @param isAllowListEnabled The new state of the allow list.
     */
     event AllowListEnabled(bool isAllowListEnabled);
 
     /**
-        @notice Emitted when a new bond is created
-        @param newBond The address of the newley deployed bond
-        Inherit createBond
+        @notice Emitted when a new bond is created.
+        @param newBond The address of the newley deployed bond.
+        @param name Passed into the ERC20 token to define the name.
+        @param symbol Passed into the ERC20 token to define the symbol.
+        @param owner Ownership of the created Bond is transferred to this
+            address by way of DEFAULT_ADMIN_ROLE. The ability to withdraw is 
+            given by WITHDRAW_ROLE, and tokens are minted to this address. See
+            `initialize` in `Bond`.
+        @param maturityDate The timestamp at which the Bond will mature.
+        @param paymentToken The ERC20 token address the Bond is redeemable for.
+        @param collateralToken The ERC20 token address the Bond is backed by.
+        @param collateralTokenAmount The amount of collateral tokens per bond.
+        @param convertibleTokenAmount The amount of convertible tokens per bond.
+        @param bonds The amount of Bonds given to the owner during the one-time
+            mint during the `Bond`'s `initialize`.
     */
     event BondCreated(
         address newBond,
@@ -26,37 +38,39 @@ interface IBondFactory {
         uint256 bonds
     );
 
-    /// @notice fails if the collateral token takes a fee
+    /// @notice Fails if the collateralToken takes a fee.
     error InvalidDeposit();
 
-    /// @notice Decimals with more than 18 digits are not supported
+    /// @notice Decimals with more than 18 digits are not supported.
     error DecimalsOver18();
 
-    /// @notice maturity date is not valid
+    /// @notice Maturity date is not valid.
     error InvalidMaturityDate();
 
-    /// @notice There must be more collateral tokens than convertible tokens
+    /// @notice There must be more collateralTokens than convertibleTokens.
     error CollateralTokenAmountLessThanConvertibleTokenAmount();
 
-    /// @notice max bonds must be a positive number
+    /// @notice Bonds must be minted during initialization.
     error ZeroBondsToMint();
 
-    /// @notice payment and collateral token can not be the same
+    /// @notice The paymentToken and collateralToken must be different.
     error TokensMustBeDifferent();
 
     /**
-        @notice Creates a bond
-        @param name Name of the bond
-        @param symbol Ticker symbol for the bond
-        @param maturityDate Timestamp of when the bond matures
-        @param paymentToken Address of the token being paid
-        @param collateralToken Address of the collateral to use for the bond
-        @param collateralTokenAmount Number of all collateral tokens that the bonds will convert into
-        @param convertibleTokenAmount Number of the collateral token that all bonds will convert into
-        @param bonds number of bonds to mint
-        @dev This uses a clone to save on deployment costs which adds a slight overhead
-            everytime users interact with the bonds - but saves on gas during deployment
-        @return clone the address of the newly created bond-clone
+        @notice Creates a new Bond.
+        @param name Passed into the ERC20 token to define the name.
+        @param symbol Passed into the ERC20 token to define the symbol.
+        @param maturityDate The timestamp at which the Bond will mature.
+        @param paymentToken The ERC20 token address the Bond is redeemable for.
+        @param collateralToken The ERC20 token address the Bond is backed by.
+        @param collateralTokenAmount The amount of collateral tokens per bond.
+        @param convertibleTokenAmount The amount of convertible tokens per bond.
+        @param bonds The amount of Bonds given to the owner during the one-time
+            mint during the `Bond`'s `initialize`.
+        @dev This uses a clone to save on deployment costs which adds a slight
+            overhead when users interact with the bonds, but also saves on gas
+            during every deployment.
+        @return clone The address of the newly created Bond.
     */
     function createBond(
         string memory name,
@@ -69,27 +83,29 @@ interface IBondFactory {
         uint256 bonds
     ) external returns (address clone);
 
-    /// @notice when enabled, issuance is restricted to those with the ISSUER_ROLE
+    /// @notice If enabled, issuance is restricted to those with ISSUER_ROLE.
     function isAllowListEnabled() external view returns (bool);
 
     /**
-     @notice Check if a specific address is a porter bond created by this factory
-     @dev this is useful if we need to check if a bond is a porter bond on chain
-     for example, if we want to make a new contract that accepts any porter bonds and exchanges them
-     for new bonds, the exchange contract would need a way to know that the bonds are porter bonds
+        @notice Check if the address was created by this Bond factory.
+        @dev This is used to check if a bond was issued by this contract on-chain.
+            For example, if we want to make a new contract that accepts any issued
+            bonds and exchanges them for new Bonds, the exchange contract would need
+            a way to know that the Bonds are owned by this contract.
     */
     function isBond(address) external view returns (bool);
 
     /**
-        @notice Turns the allow list on or off
-        @param _isAllowListEnabled If the allow list should be enabled or not
-        @dev Must be called by the current owner
+        @notice Turns the allow list on or off.
+        @param _isAllowListEnabled If the allow list should be enabled or not.
+        @dev Must be called by the current owner.
     */
     function setIsAllowListEnabled(bool _isAllowListEnabled) external;
 
     /**
-     @notice Address where the bond implementation contract is stored
-     @dev this is needed since we are using a clone proxy
+        @notice Address where the bond implementation contract is stored.
+        @dev This is needed since we are using a clone proxy.
+        @return The implementation address.
     */
     function tokenImplementation() external view returns (address);
 }

--- a/contracts/interfaces/IBondFactory.sol
+++ b/contracts/interfaces/IBondFactory.sol
@@ -88,10 +88,11 @@ interface IBondFactory {
 
     /**
         @notice Check if the address was created by this Bond factory.
-        @dev This is used to check if a bond was issued by this contract on-chain.
-            For example, if we want to make a new contract that accepts any issued
-            bonds and exchanges them for new Bonds, the exchange contract would need
-            a way to know that the Bonds are owned by this contract.
+        @dev This is used to check if a bond was issued by this contract
+            on-chain. For example, if we want to make a new contract that
+            accepts any issued bonds and exchanges them for new Bonds, the
+            exchange contract would need a way to know that the Bonds are owned
+            by this contract.
     */
     function isBond(address) external view returns (bool);
 

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -1,9 +1,13 @@
 # Bond
 
-A custom ERC20 token that can be used to issue bonds.The contract handles issuance, payment, conversion, and redemption of bonds.
+
+A custom ERC20 token that can be used to issue bonds.The contract handles issuance, payment, conversion, and redemption.
+
+
 
 
 ## Events
+
 
 ### Approval
 
@@ -12,142 +16,226 @@ A custom ERC20 token that can be used to issue bonds.The contract handles issuan
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>owner</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>value</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### CollateralWithdraw
 
-emitted when collateral is withdrawn
+
+Emitted when collateral is withdrawn.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>token</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### Convert
 
-emitted when bond tokens are converted by a borrower
+
+Emitted when Bond tokens are converted by a borrower.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfBondsConverted</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfCollateralTokens</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### ExcessPaymentWithdraw
 
-emitted when payment over the required payment amount is withdrawn
+
+Emitted when payment over the required amount is withdrawn.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>token</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### Payment
 
-emitted when a portion of the bond&#39;s principal is paid
+
+Emitted when a portion of the Bond&#39;s principal is paid.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### Redeem
 
-emitted when a bond is redeemed
+
+Emitted when a Bond is redeemed.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>paymentToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfBondsRedeemed</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfPaymentTokensReceived</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfCollateralTokens</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### RoleAdminChanged
 
@@ -156,20 +244,33 @@ emitted when a bond is redeemed
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>previousAdminRole</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>newAdminRole</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### RoleGranted
 
@@ -178,20 +279,33 @@ emitted when a bond is redeemed
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>sender</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### RoleRevoked
 
@@ -200,42 +314,68 @@ emitted when a bond is redeemed
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>sender</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### TokenSweep
 
-emitted when payment over the required payment amount is withdrawn
+
+Emitted when a token is swept by the contract owner.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address </td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>contract IERC20Metadata </td>
     <td>token</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### Transfer
 
@@ -244,52 +384,100 @@ emitted when payment over the required payment amount is withdrawn
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>to</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>value</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 
 ## Errors
 
+
 ### BondNotYetMaturedOrPaid
-* operation restricted because the bond is not yet matured or paid
+
+* Operation restricted because the bond has not matured or paid.
+
+
+
+
 
 
 
 ### BondPastMaturity
-* operation restricted because the bond has matured
+
+* Operation restricted because the bond has matured.
+
+
+
+
 
 
 
 ### NoPaymentToWithdraw
-* There is no excess payment in the contract that is avaliable to withdraw
+
+* Attempted to withdraw with no excess payment in the contract.
+
+
+
+
 
 
 
 ### PaymentMet
-* attempted to pay after payment was met
+
+* Attempted to pay after payment was met.
+
+
+
+
 
 
 
 ### SweepDisallowedForToken
-* attempted to sweep a token used in the contract
+
+* Attempted to sweep a token used in the contract.
+
+
+
+
 
 
 
 ### ZeroAmount
-* attempted to perform an action that would do nothing
+
+* Attempted to perform an action that would do nothing.
+
+
+
+
+
+
 
 
 
@@ -299,11 +487,17 @@ emitted when payment over the required payment amount is withdrawn
 ## Methods
 
 
+
 ### DEFAULT_ADMIN_ROLE
+
 
 ```solidity
 function DEFAULT_ADMIN_ROLE() external view returns (bytes32)
+
 ```
+
+
+
 
 
 
@@ -312,305 +506,490 @@ function DEFAULT_ADMIN_ROLE() external view returns (bytes32)
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### WITHDRAW_ROLE
 
+
 ```solidity
 function WITHDRAW_ROLE() external view returns (bytes32)
+
 ```
 
-this role permits the withdraw of collateral from the contract
+This role permits the withdraw of collateral from the contract
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### allowance
 
+
 ```solidity
 function allowance(address owner, address spender) external view returns (uint256)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>owner</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### amountOverPaid
 
+
 ```solidity
 function amountOverPaid() external view returns (uint256 overpayment)
+
 ```
 
-gets the amount that was overpaid and can be withdrawn 
+The amount that was overpaid and can be withdrawn.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    amount that was overpaid     </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    Amount that was overpaid.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### amountOwed
 
+
 ```solidity
 function amountOwed() external view returns (uint256)
+
 ```
 
-the amount of payment tokens required to fully pay the contract
+The amount of paymentTokens required to fully pay the contract.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of payment tokens    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The amount of paymentTokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### approve
 
+
 ```solidity
 function approve(address spender, uint256 amount) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### balanceOf
 
+
 ```solidity
 function balanceOf(address account) external view returns (uint256)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### burn
 
+
 ```solidity
 function burn(uint256 amount) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### burnFrom
 
+
 ```solidity
 function burnFrom(address account, uint256 amount) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### collateralBalance
 
+
 ```solidity
 function collateralBalance() external view returns (uint256)
+
 ```
 
-gets the external balance of the ERC20 collateral token
+The external balance of the ERC20 collateral token.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of collateralTokens in the contract    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The amount of collateralTokens in the contract.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralRatio
 
+
 ```solidity
 function collateralRatio() external view returns (uint256)
+
 ```
 
-the ratio of collateral tokens per bond with
+The ratio of collateralTokens per Bond.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of tokens backing a Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralToken
 
+
 ```solidity
 function collateralToken() external view returns (address)
+
 ```
 
-the address of the ERC20 token used as collateral backing the bond
+The ERC20 token used as collateral backing the bond.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The ERC20 token&#39;s address
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### convert
 
+
 ```solidity
 function convert(uint256 bonds) external nonpayable
+
 ```
 
-Bond holder can convert their bond to underlying collateral at the convertible ratio The bond must be convertible and not past maturity
+For convertible Bonds (ones with a convertibilityRatio &gt; 0), the Bond holder may convert their bond to underlying collateral at the convertibleRatio. The bond must also have not past maturity for this to be possible.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    the number of bonds which will be burnt and converted into the collateral at the convertibleRatio    </td>
-      </tr>
+    
+    <td>
+    The number of bonds which will be burnt and converted into the collateral at the convertibleRatio.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### convertibleRatio
 
+
 ```solidity
 function convertibleRatio() external view returns (uint256)
+
 ```
 
-the ratio of ERC20 tokens the bonds will convert into
+The ratio of convertibleTokens the bonds will convert into.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### decimals
 
+
 ```solidity
 function decimals() external view returns (uint8)
+
 ```
+
+
+
 
 
 
@@ -619,288 +998,462 @@ function decimals() external view returns (uint8)
 
 
 <table>
+
   <tr>
     <td>
-      uint8    </td>
-      </tr>
+      uint8
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### decreaseAllowance
 
+
 ```solidity
 function decreaseAllowance(address spender, uint256 subtractedValue) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>subtractedValue</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### getRoleAdmin
 
+
 ```solidity
 function getRoleAdmin(bytes32 role) external view returns (bytes32)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### grantRole
 
+
 ```solidity
 function grantRole(bytes32 role, address account) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### hasRole
 
+
 ```solidity
 function hasRole(bytes32 role, address account) external view returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### increaseAllowance
 
+
 ```solidity
 function increaseAllowance(address spender, uint256 addedValue) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>addedValue</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### initialize
 
+
 ```solidity
 function initialize(string bondName, string bondSymbol, address owner, uint256 _maturityDate, address _paymentToken, address _collateralToken, uint256 _collateralRatio, uint256 _convertibleRatio, uint256 maxSupply) external nonpayable
+
 ```
 
-this function is called one time during initial bond creation and sets up the configuration for the bond
+This one-time setup initiated by the BondFactory initializes the Bond with the given configuration.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>string </td>
     <td>bondName</td>
-        <td>
-    passed into the ERC20 token    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>bondSymbol</td>
-        <td>
-    passed into the ERC20 token    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>owner</td>
-        <td>
-    ownership of this contract transferred to this address    </td>
-      </tr>
+    
+    <td>
+    Ownership of the created Bond is transferred to this address by way of DEFAULT_ADMIN_ROLE. The ability to withdraw is  given by WITHDRAW_ROLE, and tokens are minted to this address.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_maturityDate</td>
-        <td>
-    the timestamp at which the bond will mature    </td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>_paymentToken</td>
-        <td>
-    the ERC20 token address the bond will be redeemable for at maturity    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>_collateralToken</td>
-        <td>
-    the ERC20 token address for the bond    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_collateralRatio</td>
-        <td>
-    the amount of tokens per bond needed as collateral    </td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_convertibleRatio</td>
-        <td>
-    the amount of tokens per bond a convertible bond can be converted for    </td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maxSupply</td>
-        <td>
-    the amount of bonds to mint initially    </td>
-      </tr>
+    
+    <td>
+    The amount of Bonds given to the owner during the one- time mint during this initialization.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### isFullyPaid
 
+
 ```solidity
 function isFullyPaid() external view returns (bool)
+
 ```
 
-checks if the balance of payment token covers the bond supply
+Checks if the balance of payment token covers the Bond supply.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    whether or not the bond is fully paid    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    Whether or not the Bond is fully paid.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isMature
 
+
 ```solidity
 function isMature() external view returns (bool)
+
 ```
 
-checks if the maturity date has passed (including current block timestamp)
+Checks if the maturity date has passed.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    whether or not the bond has reached the maturity date    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    Whether or not the Bond has reached the maturity date.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### maturityDate
 
+
 ```solidity
 function maturityDate() external view returns (uint256)
+
 ```
 
-A date in the future set at bond creation at which the bond will mature. Before this date, a bond token can be converted if convertible, but cannot be redeemed. Before this date, a bond token can be redeemed if the bond has been fully paid After this date, a bond token can be redeemed for the payment token, but cannot be converted.
+A date set at Bond creation when the Bond will mature.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The maturity date timestamp.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### name
 
+
 ```solidity
 function name() external view returns (string)
+
 ```
+
+
+
 
 
 
@@ -909,277 +1462,447 @@ function name() external view returns (string)
 
 
 <table>
+
   <tr>
     <td>
-      string    </td>
-      </tr>
+      string
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### pay
 
+
 ```solidity
 function pay(uint256 amount) external nonpayable
+
 ```
 
-allows the issuer to pay the bond by transferring payment token
+Allows the issuer to pay the bond by depositing payment token.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    the number of payment tokens to pay    </td>
-      </tr>
+    
+    <td>
+    The number of paymentTokens to deposit.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### paymentBalance
 
+
 ```solidity
 function paymentBalance() external view returns (uint256)
+
 ```
 
-gets the external balance of the ERC20 payment token
+Gets the external balance of the ERC20 payment token.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of paymentTokens in the contract    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens in the contract.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### paymentToken
 
+
 ```solidity
 function paymentToken() external view returns (address)
+
 ```
 
-The address of the ERC20 token this bond will be redeemable for at maturity which is paid by the borrower to unlock their collateral
+This is the token the borrower deposits into the contract and what the Bond holders will receive when redeemed.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The address of the token.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewConvertBeforeMaturity
 
+
 ```solidity
 function previewConvertBeforeMaturity(uint256 bonds) external view returns (uint256)
+
 ```
 
-the amount of collateral the given bonds would convert into if able
+Before maturity, if the given bonds are converted, this would be the number of collateralTokens received.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    the amount of bonds that would be burnt to convert into collateral    </td>
-      </tr>
+    
+    <td>
+    The number of Bonds burnt and converted into collateral.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    amount of collateral received    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens the Bonds will be converted into.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewRedeemAtMaturity
 
+
 ```solidity
 function previewRedeemAtMaturity(uint256 bonds) external view returns (uint256, uint256)
+
 ```
 
-the amount of collateral and payment tokens the bonds would redeem for at maturity
+At maturity, if the given bonds are redeemed, this would be the amount of collateralTokens and paymentTokens received.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    the amount of bonds to burn and redeem for tokens    </td>
-      </tr>
+    
+    <td>
+    The number of Bonds to burn and redeem for tokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of payment tokens to receive    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens to receive.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of collateral tokens to receive    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens to receive.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewWithdraw
 
+
 ```solidity
 function previewWithdraw() external view returns (uint256)
+
 ```
 
-the amount of collateral that the issuer would be able to  withdraw from the contract
+The amount of collateral that the issuer would be able to  withdraw from the contract.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of collateral received    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens received.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### redeem
 
+
 ```solidity
 function redeem(uint256 bonds) external nonpayable
+
 ```
 
-this function burns bonds in return for the token borrowed against the bond
+The Bond holder can burn Bonds in return for their portion of paymentTokens and collateralTokens backing the Bonds. These portions of tokens depends on the number of paymentTokens deposited. When the Bond is fully paid, redemption will result in all paymentTokens. If the Bond has reached maturity without being fully paid, a portion of the collateralTokens will be availalbe.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    the amount of bonds to redeem and burn    </td>
-      </tr>
+    
+    <td>
+    The number of bonds to redeem and burn
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### renounceRole
 
+
 ```solidity
 function renounceRole(bytes32 role, address account) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### revokeRole
 
+
 ```solidity
 function revokeRole(bytes32 role, address account) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### supportsInterface
 
+
 ```solidity
 function supportsInterface(bytes4 interfaceId) external view returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes4 </td>
     <td>interfaceId</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### sweep
 
+
 ```solidity
 function sweep(contract IERC20Metadata token) external nonpayable
+
 ```
 
-sends tokens to the issuer that were sent to this contract
+Sends tokens to the owner that are in this contract.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>contract IERC20Metadata </td>
     <td>token</td>
-        <td>
-    send the entire token balance of this address to the owner    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token to sweep and send to the owner.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### symbol
 
+
 ```solidity
 function symbol() external view returns (string)
+
 ```
+
+
+
 
 
 
@@ -1188,17 +1911,28 @@ function symbol() external view returns (string)
 
 
 <table>
+
   <tr>
     <td>
-      string    </td>
-      </tr>
+      string
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### totalSupply
 
+
 ```solidity
 function totalSupply() external view returns (uint256)
+
 ```
+
+
+
 
 
 
@@ -1207,95 +1941,150 @@ function totalSupply() external view returns (uint256)
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### transfer
 
+
 ```solidity
 function transfer(address to, uint256 amount) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>to</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### transferFrom
 
+
 ```solidity
 function transferFrom(address from, address to, uint256 amount) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>to</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
 
-### withdrawCollateral
+
+
+### withdrawExcessCollateral
+
 
 ```solidity
-function withdrawCollateral() external nonpayable
+function withdrawExcessCollateral() external nonpayable
+
 ```
 
-Withdraw collateral from bond contract the amount of collateral available to be withdrawn depends on the collateralRatio and the convertibleRatio
+A caller with the WITHDRAW_ROLE may withdraw excess collateral from bond contract. The number of collateralTokens remaining in the contract must be enough to cover the total supply of Bonds in accordance to both the collateralRatio and convertibleRatio.
+
+
+
+
 
 
 
 ### withdrawExcessPayment
 
+
 ```solidity
 function withdrawExcessPayment() external nonpayable
+
 ```
 
-withdraws any overpaid payment token 
+A caller with the WITHDRAW_ROLE can withdraw any overpaid payment token in the contract.
+
+
+
+
+
 
 
 

--- a/docs/BondFactory.md
+++ b/docs/BondFactory.md
@@ -1,73 +1,113 @@
 # BondFactory
 
-This factory contract issues new bond contracts
+
+This factory contract issues new bond contracts.
+
+
 
 
 ## Events
 
+
 ### AllowListEnabled
 
-Emitted when the allow list is toggled on or off
+
+Emitted when the allow list is toggled on or off.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>bool </td>
     <td>isAllowListEnabled</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### BondCreated
 
-Emitted when a new bond is created
+
+Emitted when a new bond is created.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address </td>
     <td>newBond</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>name</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>symbol</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>owner</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maturityDate</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>paymentToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>collateralTokenAmount</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>convertibleTokenAmount</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### RoleAdminChanged
 
@@ -76,20 +116,33 @@ Emitted when a new bond is created
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>previousAdminRole</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>newAdminRole</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### RoleGranted
 
@@ -98,20 +151,33 @@ Emitted when a new bond is created
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>sender</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### RoleRevoked
 
@@ -120,52 +186,100 @@ Emitted when a new bond is created
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>sender</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 
 ## Errors
 
+
 ### CollateralTokenAmountLessThanConvertibleTokenAmount
-* There must be more collateral tokens than convertible tokens
+
+* There must be more collateralTokens than convertibleTokens.
+
+
+
+
 
 
 
 ### DecimalsOver18
-* Decimals with more than 18 digits are not supported
+
+* Decimals with more than 18 digits are not supported.
+
+
+
+
 
 
 
 ### InvalidDeposit
-* fails if the collateral token takes a fee
+
+* Fails if the collateralToken takes a fee.
+
+
+
+
 
 
 
 ### InvalidMaturityDate
-* maturity date is not valid
+
+* Maturity date is not valid.
+
+
+
+
 
 
 
 ### TokensMustBeDifferent
-* payment and collateral token can not be the same
+
+* The paymentToken and collateralToken must be different.
+
+
+
+
 
 
 
 ### ZeroBondsToMint
-* max bonds must be a positive number
+
+* Bonds must be minted during initialization.
+
+
+
+
+
+
 
 
 
@@ -175,11 +289,17 @@ Emitted when a new bond is created
 ## Methods
 
 
+
 ### DEFAULT_ADMIN_ROLE
+
 
 ```solidity
 function DEFAULT_ADMIN_ROLE() external view returns (bytes32)
+
 ```
+
+
+
 
 
 
@@ -188,318 +308,539 @@ function DEFAULT_ADMIN_ROLE() external view returns (bytes32)
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### ISSUER_ROLE
 
+
 ```solidity
 function ISSUER_ROLE() external view returns (bytes32)
+
 ```
 
-the role required to issue bonds
+The role required to issue bonds
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### createBond
 
+
 ```solidity
 function createBond(string name, string symbol, uint256 maturityDate, address paymentToken, address collateralToken, uint256 collateralTokenAmount, uint256 convertibleTokenAmount, uint256 bonds) external nonpayable returns (address clone)
+
 ```
 
-inheritdoc IBond
+Creates a new Bond.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>string </td>
     <td>name</td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>symbol</td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maturityDate</td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>paymentToken</td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>collateralToken</td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>collateralTokenAmount</td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>convertibleTokenAmount</td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-      </tr>
+    
+    <td>
+    The amount of Bonds given to the owner during the one-time mint during the `Bond`&#39;s `initialize`.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The address of the newly created Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### getRoleAdmin
 
+
 ```solidity
 function getRoleAdmin(bytes32 role) external view returns (bytes32)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### grantRole
 
+
 ```solidity
 function grantRole(bytes32 role, address account) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### hasRole
 
+
 ```solidity
 function hasRole(bytes32 role, address account) external view returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isAllowListEnabled
 
+
 ```solidity
 function isAllowListEnabled() external view returns (bool)
+
 ```
 
-inheritdoc IBond
+If enabled, issuance is restricted to those with ISSUER_ROLE.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isBond
 
+
 ```solidity
 function isBond(address) external view returns (bool)
+
 ```
 
-inheritdoc IBond
+Check if the address was created by this Bond factory.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>_0</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### renounceRole
 
+
 ```solidity
 function renounceRole(bytes32 role, address account) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### revokeRole
 
+
 ```solidity
 function revokeRole(bytes32 role, address account) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### setIsAllowListEnabled
 
+
 ```solidity
 function setIsAllowListEnabled(bool _isAllowListEnabled) external nonpayable
+
 ```
 
-inheritdoc IBond
+Turns the allow list on or off.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bool </td>
     <td>_isAllowListEnabled</td>
-      </tr>
+    
+    <td>
+    If the allow list should be enabled or not.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### supportsInterface
 
+
 ```solidity
 function supportsInterface(bytes4 interfaceId) external view returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes4 </td>
     <td>interfaceId</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### tokenImplementation
 
+
 ```solidity
 function tokenImplementation() external view returns (address)
+
 ```
 
-inheritdoc IBond
+Address where the bond implementation contract is stored.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The implementation address.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -3,225 +3,390 @@
 
 
 
+
+
+
 ## Events
+
 
 ### CollateralWithdraw
 
-emitted when collateral is withdrawn
+
+Emitted when collateral is withdrawn.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    the address withdrawing collateral    </td>
-      </tr>
+    
+    <td>
+    The address withdrawing the collateral.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>token</td>
-        <td>
-    the address of the collateral token    </td>
-      </tr>
+    
+    <td>
+    The address of the collateralToken.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    the number of the tokens withdrawn    </td>
-      </tr>
+    
+    <td>
+    The number of collateralTokens withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### Convert
 
-emitted when bond tokens are converted by a borrower
+
+Emitted when Bond tokens are converted by a borrower.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    the address converting their tokens    </td>
-      </tr>
+    
+    <td>
+    The address converting their tokens.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-        <td>
-    the address of the collateral received    </td>
-      </tr>
+    
+    <td>
+    The address of the collateralToken.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfBondsConverted</td>
-        <td>
-    the number of burnt bonds    </td>
-      </tr>
+    
+    <td>
+    The number of burnt Bonds.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfCollateralTokens</td>
-        <td>
-    the number of collateral tokens received    </td>
-      </tr>
+    
+    <td>
+    The number of collateralTokens received.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### ExcessPaymentWithdraw
 
-emitted when payment over the required payment amount is withdrawn
+
+Emitted when payment over the required amount is withdrawn.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    the caller withdrawing the excessPaymentAmount    </td>
-      </tr>
+    
+    <td>
+    The caller withdrawing the excess payment amount.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>token</td>
-        <td>
-    the paymentToken being withdrawn    </td>
-      </tr>
+    
+    <td>
+    The paymentToken being withdrawn.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    the amount of paymentToken withdrawn    </td>
-      </tr>
+    
+    <td>
+    The amount of paymentToken withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### Payment
 
-emitted when a portion of the bond&#39;s principal is paid
+
+Emitted when a portion of the Bond&#39;s principal is paid.
+
+
+*The amount could be incorrect if the token takes a fee on transfer. *
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    the address depositing payment    </td>
-      </tr>
+    
+    <td>
+    The address depositing payment.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    Amount paid. The amount could be incorrect if the payment token takes a fee on transfer.     </td>
-      </tr>
+    
+    <td>
+    Amount paid.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### Redeem
 
-emitted when a bond is redeemed
+
+Emitted when a Bond is redeemed.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    the bond holder whose bonds are burnt    </td>
-      </tr>
+    
+    <td>
+    The Bond holder whose Bonds are burnt.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>paymentToken</td>
-        <td>
-    the address of the payment token    </td>
-      </tr>
+    
+    <td>
+    The address of the paymentToken.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-        <td>
-    the address of the collateral token    </td>
-      </tr>
+    
+    <td>
+    The address of the collateralToken.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfBondsRedeemed</td>
-        <td>
-    the amount of bonds burned for redemption    </td>
-      </tr>
+    
+    <td>
+    The amount of Bonds burned for redemption.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfPaymentTokensReceived</td>
-        <td>
-    the amount of payment tokens    </td>
-      </tr>
+    
+    <td>
+    The amount of paymentTokens.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfCollateralTokens</td>
-        <td>
-    the amount of collateral tokens    </td>
-      </tr>
+    
+    <td>
+    The amount of collateralTokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### TokenSweep
 
-emitted when payment over the required payment amount is withdrawn
+
+Emitted when a token is swept by the contract owner.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address </td>
     <td>from</td>
-        <td>
-    the caller who the tokens were sent to     </td>
-      </tr>
+    
+    <td>
+    The owner&#39;s address.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>contract IERC20Metadata </td>
     <td>token</td>
-        <td>
-    the token that was swept     </td>
-      </tr>
+    
+    <td>
+    The token that was swept.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    the amount that was swept     </td>
-      </tr>
+    
+    <td>
+    The amount that was swept.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 
 ## Errors
 
+
 ### BondNotYetMaturedOrPaid
-* operation restricted because the bond is not yet matured or paid
+
+* Operation restricted because the bond has not matured or paid.
+
+
+
+
 
 
 
 ### BondPastMaturity
-* operation restricted because the bond has matured
+
+* Operation restricted because the bond has matured.
+
+
+
+
 
 
 
 ### NoPaymentToWithdraw
-* There is no excess payment in the contract that is avaliable to withdraw
+
+* Attempted to withdraw with no excess payment in the contract.
+
+
+
+
 
 
 
 ### PaymentMet
-* attempted to pay after payment was met
+
+* Attempted to pay after payment was met.
+
+
+
+
 
 
 
 ### SweepDisallowedForToken
-* attempted to sweep a token used in the contract
+
+* Attempted to sweep a token used in the contract.
+
+
+
+
 
 
 
 ### ZeroAmount
-* attempted to perform an action that would do nothing
+
+* Attempted to perform an action that would do nothing.
+
+
+
+
+
+
 
 
 
@@ -231,481 +396,792 @@ emitted when payment over the required payment amount is withdrawn
 ## Methods
 
 
+
 ### amountOverPaid
+
 
 ```solidity
 function amountOverPaid() external view returns (uint256 overpayment)
+
 ```
 
-gets the amount that was overpaid and can be withdrawn 
+The amount that was overpaid and can be withdrawn.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    amount that was overpaid     </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    Amount that was overpaid.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### amountOwed
 
+
 ```solidity
 function amountOwed() external view returns (uint256)
+
 ```
 
-the amount of payment tokens required to fully pay the contract
+The amount of paymentTokens required to fully pay the contract.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of payment tokens    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The amount of paymentTokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralBalance
 
+
 ```solidity
 function collateralBalance() external view returns (uint256)
+
 ```
 
-gets the external balance of the ERC20 collateral token
+The external balance of the ERC20 collateral token.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of collateralTokens in the contract    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The amount of collateralTokens in the contract.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralRatio
 
+
 ```solidity
 function collateralRatio() external view returns (uint256)
+
 ```
 
-the ratio of collateral tokens per bond with
+The ratio of collateralTokens per Bond.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of tokens backing a Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralToken
 
+
 ```solidity
 function collateralToken() external view returns (address)
+
 ```
 
-the address of the ERC20 token used as collateral backing the bond
+The ERC20 token used as collateral backing the bond.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The ERC20 token&#39;s address
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### convert
 
+
 ```solidity
 function convert(uint256 bonds) external nonpayable
+
 ```
 
-Bond holder can convert their bond to underlying collateral at the convertible ratio The bond must be convertible and not past maturity
+For convertible Bonds (ones with a convertibilityRatio &gt; 0), the Bond holder may convert their bond to underlying collateral at the convertibleRatio. The bond must also have not past maturity for this to be possible.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    the number of bonds which will be burnt and converted into the collateral at the convertibleRatio    </td>
-      </tr>
+    
+    <td>
+    The number of bonds which will be burnt and converted into the collateral at the convertibleRatio.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### convertibleRatio
 
+
 ```solidity
 function convertibleRatio() external view returns (uint256)
+
 ```
 
-the ratio of ERC20 tokens the bonds will convert into
+The ratio of convertibleTokens the bonds will convert into.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### initialize
 
+
 ```solidity
 function initialize(string bondName, string bondSymbol, address owner, uint256 _maturityDate, address _paymentToken, address _collateralToken, uint256 _collateralRatio, uint256 _convertibleRatio, uint256 maxSupply) external nonpayable
+
 ```
 
-this function is called one time during initial bond creation and sets up the configuration for the bond
+This one-time setup initiated by the BondFactory initializes the Bond with the given configuration.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>string </td>
     <td>bondName</td>
-        <td>
-    passed into the ERC20 token    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>bondSymbol</td>
-        <td>
-    passed into the ERC20 token    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>owner</td>
-        <td>
-    ownership of this contract transferred to this address    </td>
-      </tr>
+    
+    <td>
+    Ownership of the created Bond is transferred to this address by way of DEFAULT_ADMIN_ROLE. The ability to withdraw is  given by WITHDRAW_ROLE, and tokens are minted to this address.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_maturityDate</td>
-        <td>
-    the timestamp at which the bond will mature    </td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>_paymentToken</td>
-        <td>
-    the ERC20 token address the bond will be redeemable for at maturity    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>_collateralToken</td>
-        <td>
-    the ERC20 token address for the bond    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_collateralRatio</td>
-        <td>
-    the amount of tokens per bond needed as collateral    </td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_convertibleRatio</td>
-        <td>
-    the amount of tokens per bond a convertible bond can be converted for    </td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maxSupply</td>
-        <td>
-    the amount of bonds to mint initially    </td>
-      </tr>
+    
+    <td>
+    The amount of Bonds given to the owner during the one- time mint during this initialization.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### isFullyPaid
 
+
 ```solidity
 function isFullyPaid() external view returns (bool)
+
 ```
 
-checks if the balance of payment token covers the bond supply
+Checks if the balance of payment token covers the Bond supply.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    whether or not the bond is fully paid    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    Whether or not the Bond is fully paid.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isMature
 
+
 ```solidity
 function isMature() external view returns (bool)
+
 ```
 
-checks if the maturity date has passed (including current block timestamp)
+Checks if the maturity date has passed.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    whether or not the bond has reached the maturity date    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    Whether or not the Bond has reached the maturity date.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### maturityDate
 
+
 ```solidity
 function maturityDate() external view returns (uint256)
+
 ```
 
-A date in the future set at bond creation at which the bond will mature. Before this date, a bond token can be converted if convertible, but cannot be redeemed. Before this date, a bond token can be redeemed if the bond has been fully paid After this date, a bond token can be redeemed for the payment token, but cannot be converted.
+A date set at Bond creation when the Bond will mature.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The maturity date timestamp.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### pay
 
+
 ```solidity
 function pay(uint256 amount) external nonpayable
+
 ```
 
-allows the issuer to pay the bond by transferring payment token
+Allows the issuer to pay the bond by depositing payment token.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    the number of payment tokens to pay    </td>
-      </tr>
+    
+    <td>
+    The number of paymentTokens to deposit.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### paymentBalance
 
+
 ```solidity
 function paymentBalance() external view returns (uint256)
+
 ```
 
-gets the external balance of the ERC20 payment token
+Gets the external balance of the ERC20 payment token.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of paymentTokens in the contract    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens in the contract.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### paymentToken
 
+
 ```solidity
 function paymentToken() external view returns (address)
+
 ```
 
-The address of the ERC20 token this bond will be redeemable for at maturity which is paid by the borrower to unlock their collateral
+This is the token the borrower deposits into the contract and what the Bond holders will receive when redeemed.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The address of the token.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewConvertBeforeMaturity
 
+
 ```solidity
 function previewConvertBeforeMaturity(uint256 bonds) external view returns (uint256)
+
 ```
 
-the amount of collateral the given bonds would convert into if able
+Before maturity, if the given bonds are converted, this would be the number of collateralTokens received.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    the amount of bonds that would be burnt to convert into collateral    </td>
-      </tr>
+    
+    <td>
+    The number of Bonds burnt and converted into collateral.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    amount of collateral received    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens the Bonds will be converted into.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewRedeemAtMaturity
 
+
 ```solidity
 function previewRedeemAtMaturity(uint256 bonds) external view returns (uint256, uint256)
+
 ```
 
-the amount of collateral and payment tokens the bonds would redeem for at maturity
+At maturity, if the given bonds are redeemed, this would be the amount of collateralTokens and paymentTokens received.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    the amount of bonds to burn and redeem for tokens    </td>
-      </tr>
+    
+    <td>
+    The number of Bonds to burn and redeem for tokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of payment tokens to receive    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens to receive.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of collateral tokens to receive    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens to receive.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewWithdraw
 
+
 ```solidity
 function previewWithdraw() external view returns (uint256)
+
 ```
 
-the amount of collateral that the issuer would be able to  withdraw from the contract
+The amount of collateral that the issuer would be able to  withdraw from the contract.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    the amount of collateral received    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens received.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### redeem
 
+
 ```solidity
 function redeem(uint256 bonds) external nonpayable
+
 ```
 
-this function burns bonds in return for the token borrowed against the bond
+The Bond holder can burn Bonds in return for their portion of paymentTokens and collateralTokens backing the Bonds. These portions of tokens depends on the number of paymentTokens deposited. When the Bond is fully paid, redemption will result in all paymentTokens. If the Bond has reached maturity without being fully paid, a portion of the collateralTokens will be availalbe.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    the amount of bonds to redeem and burn    </td>
-      </tr>
+    
+    <td>
+    The number of bonds to redeem and burn
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### sweep
 
+
 ```solidity
 function sweep(contract IERC20Metadata token) external nonpayable
+
 ```
 
-sends tokens to the issuer that were sent to this contract
+Sends tokens to the owner that are in this contract.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>contract IERC20Metadata </td>
     <td>token</td>
-        <td>
-    send the entire token balance of this address to the owner    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token to sweep and send to the owner.
+    </td>
+    
+  </tr>
+
 </table>
 
 
-### withdrawCollateral
+
+
+
+### withdrawExcessCollateral
+
 
 ```solidity
-function withdrawCollateral() external nonpayable
+function withdrawExcessCollateral() external nonpayable
+
 ```
 
-Withdraw collateral from bond contract the amount of collateral available to be withdrawn depends on the collateralRatio and the convertibleRatio
+A caller with the WITHDRAW_ROLE may withdraw excess collateral from bond contract. The number of collateralTokens remaining in the contract must be enough to cover the total supply of Bonds in accordance to both the collateralRatio and convertibleRatio.
+
+
+
+
 
 
 
 ### withdrawExcessPayment
 
+
 ```solidity
 function withdrawExcessPayment() external nonpayable
+
 ```
 
-withdraws any overpaid payment token 
+A caller with the WITHDRAW_ROLE can withdraw any overpaid payment token in the contract.
+
+
+
+
+
 
 
 

--- a/docs/interfaces/IBondFactory.md
+++ b/docs/interfaces/IBondFactory.md
@@ -3,107 +3,222 @@
 
 
 
+
+
+
 ## Events
+
 
 ### AllowListEnabled
 
-Emitted when the allow list is toggled on or off
+
+Emitted when the allow list is toggled on or off.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>bool </td>
     <td>isAllowListEnabled</td>
-        <td>
-    the new state of the allow list    </td>
-      </tr>
+    
+    <td>
+    The new state of the allow list.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### BondCreated
 
-Emitted when a new bond is created
+
+Emitted when a new bond is created.
+
+
+
 
 
 
 
 <table>
+
   <tr>
     <td>address </td>
     <td>newBond</td>
-        <td>
-    The address of the newley deployed bond Inherit createBond    </td>
-      </tr>
+    
+    <td>
+    The address of the newley deployed bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>name</td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>symbol</td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>owner</td>
-      </tr>
+    
+    <td>
+    Ownership of the created Bond is transferred to this address by way of DEFAULT_ADMIN_ROLE. The ability to withdraw is  given by WITHDRAW_ROLE, and tokens are minted to this address. See `initialize` in `Bond`.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maturityDate</td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>paymentToken</td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>collateralTokenAmount</td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>convertibleTokenAmount</td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-      </tr>
+    
+    <td>
+    The amount of Bonds given to the owner during the one-time mint during the `Bond`&#39;s `initialize`.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 
 ## Errors
 
+
 ### CollateralTokenAmountLessThanConvertibleTokenAmount
-* There must be more collateral tokens than convertible tokens
+
+* There must be more collateralTokens than convertibleTokens.
+
+
+
+
 
 
 
 ### DecimalsOver18
-* Decimals with more than 18 digits are not supported
+
+* Decimals with more than 18 digits are not supported.
+
+
+
+
 
 
 
 ### InvalidDeposit
-* fails if the collateral token takes a fee
+
+* Fails if the collateralToken takes a fee.
+
+
+
+
 
 
 
 ### InvalidMaturityDate
-* maturity date is not valid
+
+* Maturity date is not valid.
+
+
+
+
 
 
 
 ### TokensMustBeDifferent
-* payment and collateral token can not be the same
+
+* The paymentToken and collateralToken must be different.
+
+
+
+
 
 
 
 ### ZeroBondsToMint
-* max bonds must be a positive number
+
+* Bonds must be minted during initialization.
+
+
+
+
+
+
 
 
 
@@ -113,162 +228,264 @@ Emitted when a new bond is created
 ## Methods
 
 
+
 ### createBond
+
 
 ```solidity
 function createBond(string name, string symbol, uint256 maturityDate, address paymentToken, address collateralToken, uint256 collateralTokenAmount, uint256 convertibleTokenAmount, uint256 bonds) external nonpayable returns (address clone)
+
 ```
 
-Creates a bond
+Creates a new Bond.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>string </td>
     <td>name</td>
-        <td>
-    Name of the bond    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>symbol</td>
-        <td>
-    Ticker symbol for the bond    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maturityDate</td>
-        <td>
-    Timestamp of when the bond matures    </td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>paymentToken</td>
-        <td>
-    Address of the token being paid    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>collateralToken</td>
-        <td>
-    Address of the collateral to use for the bond    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>collateralTokenAmount</td>
-        <td>
-    Number of all collateral tokens that the bonds will convert into    </td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>convertibleTokenAmount</td>
-        <td>
-    Number of the collateral token that all bonds will convert into    </td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    number of bonds to mint    </td>
-      </tr>
+    
+    <td>
+    The amount of Bonds given to the owner during the one-time mint during the `Bond`&#39;s `initialize`.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-        <td>
-    the address of the newly created bond-clone    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The address of the newly created Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isAllowListEnabled
 
+
 ```solidity
 function isAllowListEnabled() external view returns (bool)
+
 ```
 
-when enabled, issuance is restricted to those with the ISSUER_ROLE
+If enabled, issuance is restricted to those with ISSUER_ROLE.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isBond
 
+
 ```solidity
 function isBond(address) external view returns (bool)
+
 ```
 
-Check if a specific address is a porter bond created by this factory
+Check if the address was created by this Bond factory.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>_0</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### setIsAllowListEnabled
 
+
 ```solidity
 function setIsAllowListEnabled(bool _isAllowListEnabled) external nonpayable
+
 ```
 
-Turns the allow list on or off
+Turns the allow list on or off.
+
+
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bool </td>
     <td>_isAllowListEnabled</td>
-        <td>
-    If the allow list should be enabled or not    </td>
-      </tr>
+    
+    <td>
+    If the allow list should be enabled or not.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### tokenImplementation
 
+
 ```solidity
 function tokenImplementation() external view returns (address)
+
 ```
 
-Address where the bond implementation contract is stored
+Address where the bond implementation contract is stored.
+
+
+
 
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The implementation address.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 

--- a/spec/bond.md
+++ b/spec/bond.md
@@ -8,7 +8,7 @@ A new `Bond` contract is created for each [borrower](https://docs.porter.finance
 
 - Depositing collateral and minting new `Bonds` via `mint()`
 - Handling repayment for the issuer via `repay()`
-- withdrawing collateral `withdrawCollateral()`
+- withdrawing collateral `withdrawExcessCollateral()`
 
 ### Lenders
 

--- a/spec/overview.md
+++ b/spec/overview.md
@@ -15,7 +15,7 @@ A new `Bond` contract is created for each [borrower](https://docs.porter.finance
 Borrowers are on chain entities that want to borrow stablecoins using their native token as collateral with a fixed interest rate and no liquidation risk.
 
 - Creation and minting new `BondTokens` via `initialize()` and `mint()`
-- Depositing/withdrawing collateral via `mint()` and `withdrawCollateral()`
+- Depositing/withdrawing collateral via `mint()` and `withdrawExcessCollateral()`
 - Handling convertibility via a configured ratio and the ability for lenders to convert their `BondTokens` using `convert()`
 - Handling payment for the issuer via `pay()`
 - Allowing bond redemption for the bond holders via `redeem()`

--- a/spec/permissions.md
+++ b/spec/permissions.md
@@ -63,7 +63,7 @@ The bond admin is able to grant or revoke the `WITHDRAW_ROLE` as well as the `MI
 The bond admin is automatically granted this role upon the creation of the bond. Additional withdrawers can be added by the bond admin.
 
 Methods only callable by this role:
-`Bond.withdrawCollateral()`
+`Bond.withdrawExcessCollateral()`
 Only addresses with this role are able to withdraw bond collateral. This role will be used in the future to allow refinancing of loans.
 
 ### MINT_ROLE

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -405,7 +405,7 @@ describe("Bond", () => {
           });
         });
       });
-      describe("#withdrawCollateral", async () => {
+      describe("#withdrawExcessCollateral", async () => {
         beforeEach(async () => {
           bond = bondWithTokens.nonConvertible.bond;
           config = bondWithTokens.nonConvertible.config;
@@ -448,7 +448,7 @@ describe("Bond", () => {
               expect(await bond.totalSupply()).to.not.equal(0);
 
               await expectTokenDelta(
-                bond.withdrawCollateral,
+                bond.withdrawExcessCollateral,
                 collateralToken,
                 owner,
                 bond.address,
@@ -513,13 +513,13 @@ describe("Bond", () => {
               ).wait();
               await (await bond.pay(targetPayment)).wait();
               const amountOwed = await bond.amountOwed();
-              await (await bond.withdrawCollateral()).wait();
+              await (await bond.withdrawExcessCollateral()).wait();
               expect(await bond.amountOwed()).to.be.equal(amountOwed);
             });
 
             it("should revert when called by non-withdrawer", async () => {
               await expect(
-                bond.connect(attacker).withdrawCollateral()
+                bond.connect(attacker).withdrawExcessCollateral()
               ).to.be.revertedWith(
                 `AccessControl: account ${attacker.address.toLowerCase()} is missing role ${withdrawRole}`
               );
@@ -527,12 +527,12 @@ describe("Bond", () => {
 
             it("should grant and revoke withdraw role", async () => {
               await bond.grantRole(withdrawRole, attacker.address);
-              await expect(bond.connect(attacker).withdrawCollateral()).to.not
-                .be.reverted;
+              await expect(bond.connect(attacker).withdrawExcessCollateral()).to
+                .not.be.reverted;
 
               await bond.revokeRole(withdrawRole, attacker.address);
               await expect(
-                bond.connect(attacker).withdrawCollateral()
+                bond.connect(attacker).withdrawExcessCollateral()
               ).to.be.revertedWith(
                 `AccessControl: account ${attacker.address.toLowerCase()} is missing role ${withdrawRole}`
               );
@@ -595,7 +595,7 @@ describe("Bond", () => {
               await bond.burn(config.maxSupply);
               expect(await bond.totalSupply()).to.equal(0);
               await expectTokenDelta(
-                bond.withdrawCollateral,
+                bond.withdrawExcessCollateral,
                 collateralToken,
                 owner,
                 owner.address,


### PR DESCRIPTION
I went through all of the comments and did
* capital letters
* collateral token = collateralToken 
* payment token = paymentToken
* convertible token = convertibleToken
* bond = Bond
* periods at the end.
* removed trailing off comments
* removed out of date information
* refactored some comments
* capped at 80 characters

additionally, the bondfactory which used to have "inherit createbond" i changed to be more explicit. i realize this will be annoying to change, but I think that, since there is no support for inheriting the params from a different-named function, i would rather have the documentation covering everything.

i also changed withdrawCollateral to withdrawExcessCollateral because I thought it made sense and is consistent with our withdrawExcessPayment.

closes #204 
