### PR TITLE
Remove unnecessary reentrancy guard

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -332,11 +332,7 @@ contract Bond is
         @dev collateral, payment, and the bond itself cannot be swept
         @param token send the entire token balance of this address to the owner
     */
-    function sweep(IERC20Metadata token)
-        external
-        nonReentrant
-        onlyRole(DEFAULT_ADMIN_ROLE)
-    {
+    function sweep(IERC20Metadata token) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (
             address(token) == paymentToken || address(token) == collateralToken
         ) {

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -120,11 +120,7 @@ contract Bond is
     }
 
     /// @inheritdoc IBond
-    function withdrawExcessCollateral()
-        external
-        nonReentrant
-        onlyRole(WITHDRAW_ROLE)
-    {
+    function withdrawExcessCollateral() external onlyRole(WITHDRAW_ROLE) {
         uint256 collateralToSend = previewWithdraw();
 
         // Saves an extra SLOAD
@@ -297,11 +293,7 @@ contract Bond is
     }
 
     /// @inheritdoc IBond
-    function withdrawExcessPayment()
-        external
-        nonReentrant
-        onlyRole(WITHDRAW_ROLE)
-    {
+    function withdrawExcessPayment() external onlyRole(WITHDRAW_ROLE) {
         uint256 overpayment = amountOverPaid();
         if (overpayment <= 0) {
             revert NoPaymentToWithdraw();


### PR DESCRIPTION
This PR removes the `nonReentrant` modifier from Openzeppelin's  [Reentrancy Guard](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/security/ReentrancyGuard.sol#L50). These were redundant because the methods for `sweep`, `withdrawExcessCollateral` and `withdrawExcessPayment` are already role-restricted. The removal of these guards save about 10k gas on each call. 

These guards while redundant assuming the owner of the contract acts in good faith, do open up a possibility to have malicious token interactions that could put the contract into a state that is unexpected. This problem, however, is negated by the introduction of the token whitelist.

closes #213 