### PR TITLE
Make users aware of Permissions

### DIFF
--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -46,11 +46,14 @@ contract BondFactory is IBondFactory, AccessControl {
         _;
     }
 
+    /*
+        When deployed, the deployer will be granted the DEFAULT_ADMIN_ROLE. This
+        gives the ability the ability to call `grantRole` to grant access to
+        the ISSUER_ROLE as well as the ability to toggle if the allow list
+        is enabled or not at any time.
+    */
     constructor() {
         tokenImplementation = address(new Bond());
-        // This grants the user deploying this contract the DEFAULT_ADMIN_ROLE
-        // which gives them the ability to call grantRole to grant access to
-        // the ISSUER_ROLE.
         _grantRole(DEFAULT_ADMIN_ROLE, _msgSender());
     }
 

--- a/spec/permissions.md
+++ b/spec/permissions.md
@@ -5,6 +5,7 @@ There are a few different entities with different permissions in the porter prot
 ## Porter admins can
 
 - Control allow-list settings
+- Grant and revoke issuer role to accounts
 
 ## Borrowers can
 
@@ -33,8 +34,7 @@ Method only callable by this role
 `BondFactory.revokeRole('ISSUER_ROLE)`
 `BondFactory.isAllowListEnabled(bool)`
 
-The Porter Admin can grant or revoke the `ISSUER_ROLE`, in addition to enabled or disabling the allow-list for creating new bonds.
-This role has the ability to be revoked. Disabling the allow list then revoking this role would leave `BondFactory` in a fully permissionless state.
+The Porter Admin can grant or revoke the `ISSUER_ROLE`, in addition to enabled or disabling the allow-list for creating new bonds. This toggling of the allow-list like adding or removing new issuers is not time-locked. However, this role has the ability to be revoked. Disabling the allow list then revoking this role would leave `BondFactory` in a fully permissionless state.
 
 ### Issuer - ISSUER_ROLE
 


### PR DESCRIPTION
The change of the allow list and issuer list can be changed at any time and instead of adding a timelock, make the users aware. 

This will not be done randomly as the porter admin will be controlled by our multisig and later likely by the community with a timelock.