### PR TITLE
Initialize token implementation

### DIFF
--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -46,6 +46,10 @@ contract BondFactory is IBondFactory, AccessControl {
         _;
     }
 
+    /*
+        The token implementation is instantiated and initialized with dummy
+        values so that it is not initialized by another user.
+    */
     constructor() {
         tokenImplementation = address(new Bond());
         Bond(tokenImplementation).initialize(

--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -48,6 +48,18 @@ contract BondFactory is IBondFactory, AccessControl {
 
     constructor() {
         tokenImplementation = address(new Bond());
+        Bond(tokenImplementation).initialize(
+            "",
+            "",
+            address(this),
+            0,
+            address(0),
+            address(1),
+            0,
+            0,
+            0
+        );
+
         // This grants the user deploying this contract the DEFAULT_ADMIN_ROLE
         // which gives them the ability to call grantRole to grant access to
         // the ISSUER_ROLE.


### PR DESCRIPTION
This PR addresses the comment that anyone can call initialize on the bond contract. I think this makes it look bad and do not think there is a reason to do this besides the implementation contract's bond could be initialized with some advertisement or other unsavory bond name and symbol. This would be seen when our bond is verified on etherscan I believe. The bond will not be marked as a "clone" of the factory because it was not created through the `createBond` method.