### PR TITLE
allow preview for payment amount

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -121,7 +121,7 @@ contract Bond is
 
     /// @inheritdoc IBond
     function withdrawExcessCollateral() external onlyRole(WITHDRAW_ROLE) {
-        uint256 collateralToSend = previewWithdraw();
+        uint256 collateralToSend = previewWithdraw(0);
 
         // Saves an extra SLOAD
         address collateral = collateralToken;
@@ -232,8 +232,8 @@ contract Bond is
     }
 
     /// @inheritdoc IBond
-    function previewWithdraw() public view returns (uint256) {
-        uint256 tokensCoveredByPayment = paymentBalance();
+    function previewWithdraw(uint256 payment) public view returns (uint256) {
+        uint256 tokensCoveredByPayment = paymentBalance() + payment;
         uint256 collateralTokensRequired = 0;
         if (tokensCoveredByPayment < totalSupply()) {
             collateralTokensRequired = (totalSupply() - tokensCoveredByPayment)

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -274,9 +274,10 @@ interface IBond {
             bond is NOT paid AND mature (Defaulted)
                 to cover collateralRatio: totalUncoveredSupply * collateralRatio
                 to cover convertibleRatio: 0
+        @param payment previews amount withdrawable after a payment
         @return The number of collateralTokens received.
      */
-    function previewWithdraw() external view returns (uint256);
+    function previewWithdraw(uint256 payment) external view returns (uint256);
 
     /**
         @notice The Bond holder can burn Bonds in return for their portion of

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -287,7 +287,7 @@ interface IBond {
             bond is NOT paid AND mature (Defaulted)
                 to cover collateralRatio: totalUncoveredSupply * collateralRatio
                 to cover convertibleRatio: 0
-        @param payment previews amount withdrawable after a payment
+        @param payment The amount of paymentToken to add when previewing a withdraw.
         @return The number of collateralTokens received.
      */
     function previewWithdraw(uint256 payment) external view returns (uint256);

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -1054,11 +1054,21 @@ At maturity, if the given bonds are redeemed, this would be the amount of collat
 ### previewWithdraw
 
 ```solidity
-function previewWithdraw() external view returns (uint256)
+function previewWithdraw(uint256 payment) external view returns (uint256)
 ```
 
 The amount of collateral that the issuer would be able to  withdraw from the contract.
 
+#### Parameters
+
+<table>
+  <tr>
+    <td>uint256 </td>
+    <td>payment</td>
+        <td>
+    previews amount withdrawable after a payment    </td>
+      </tr>
+</table>
 
 #### Returns
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -639,11 +639,21 @@ At maturity, if the given bonds are redeemed, this would be the amount of collat
 ### previewWithdraw
 
 ```solidity
-function previewWithdraw() external view returns (uint256)
+function previewWithdraw(uint256 payment) external view returns (uint256)
 ```
 
 The amount of collateral that the issuer would be able to  withdraw from the contract.
 
+#### Parameters
+
+<table>
+  <tr>
+    <td>uint256 </td>
+    <td>payment</td>
+        <td>
+    previews amount withdrawable after a payment    </td>
+      </tr>
+</table>
 
 #### Returns
 

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -645,7 +645,7 @@ describe("Bond", () => {
                 bond.address,
                 utils.parseEther("1")
               );
-              expect(await bond.previewWithdraw()).to.equal(
+              expect(await bond.previewWithdraw(0)).to.equal(
                 utils.parseEther("1")
               );
             });

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -107,7 +107,7 @@ export const payAndWithdraw = async ({
 }) => {
   await paymentToken.approve(bond.address, paymentTokenAmount);
   await (await bond.pay(paymentTokenAmount)).wait();
-  expect(await bond.previewWithdraw()).to.equal(collateralToReceive);
+  expect(await bond.previewWithdraw(0)).to.equal(collateralToReceive);
 };
 
 export const burnAndWithdraw = async ({
@@ -120,7 +120,7 @@ export const burnAndWithdraw = async ({
   collateralToReceive: BigNumber;
 }) => {
   await (await bond.burn(sharesToBurn)).wait();
-  expect(await bond.previewWithdraw()).to.equal(collateralToReceive);
+  expect(await bond.previewWithdraw(0)).to.equal(collateralToReceive);
 };
 
 export const redeemAndCheckTokens = async ({


### PR DESCRIPTION
# Problem 
There is currently not a good way for a user to know much collateral with be unlocked from a payment. An issuer may wonder "if i pay 10000, how much collateral will I be able to withdraw?" 

This adds that functionality to the `previewWithdraw` method. If the user is paying back 10,000 the frontend could call 

```javascript
<> After paying you'll be able to withdraw ${previewWithdraw(10,000)} tokens! </>
```

or...
How much collateral is unlocked specifically from the payment? `previewWithdraw(10,000) - previewWithdraw(0)`

# Feedback plz 

I'm looking for suggestions for maybe a better way to do this. 

This is how I thought about doing it with the least number of code modifications. 