### PR TITLE
pass in number of tokens to withdraw

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -111,21 +111,20 @@ contract Bond is
     }
 
     /// @inheritdoc IBond
-
-    function withdrawExcessCollateral(address receiver) external onlyOwner {
-        uint256 collateralToSend = previewWithdraw(0);
+    function withdrawExcessCollateral(uint256 amount, address receiver)
+        external
+        onlyOwner
+    {
+        if (amount > previewWithdraw(0)) {
+            revert NotEnoughCollateral();
+        }
 
         // Saves an extra SLOAD
         address collateral = collateralToken;
 
-        IERC20Metadata(collateral).safeTransfer(receiver, collateralToSend);
+        IERC20Metadata(collateral).safeTransfer(receiver, amount);
 
-        emit CollateralWithdraw(
-            _msgSender(),
-            receiver,
-            collateral,
-            collateralToSend
-        );
+        emit CollateralWithdraw(_msgSender(), receiver, collateral, amount);
     }
 
     /// @inheritdoc IBond

--- a/contracts/echidna/TestBond.sol
+++ b/contracts/echidna/TestBond.sol
@@ -112,9 +112,9 @@ contract TestBond {
     }
 
     function withdrawExcessCollateral() public {
-        try bond.withdrawExcessCollateral(msg.sender) {} catch Error(
-            string memory reason
-        ) {
+        try
+            bond.withdrawExcessCollateral(bond.previewWithdraw(0), msg.sender)
+        {} catch Error(string memory reason) {
             emit AssertionFailed(reason);
         }
         checkGeneralInvariants();

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -22,6 +22,9 @@ interface IBond {
     /// @notice Attempted to withdraw with no excess payment in the contract.
     error NoPaymentToWithdraw();
 
+    /// @notice Attempted to withdraw more collateral than avaliable
+    error NotEnoughCollateral();
+
     /**
         @notice Emitted when Bond tokens are converted by a borrower.
         @param from The address converting their tokens.
@@ -318,9 +321,11 @@ interface IBond {
             from bond contract. The number of collateralTokens remaining in the
             contract must be enough to cover the total supply of Bonds in
             accordance to both the collateralRatio and convertibleRatio.
+        @param amount The amount of collateral to withdraw. Reverts if this number is greater than avaliable. 
         @param receiver The address that is transferred the excess collateral.
     */
-    function withdrawExcessCollateral(address receiver) external;
+    function withdrawExcessCollateral(uint256 amount, address receiver)
+        external;
 
     /**
         @notice The Owner can withdraw any overpaid

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -242,6 +242,11 @@ Emitted when a token is swept by the contract owner.
 
 
 
+### NotEnoughCollateral
+* Attempted to withdraw more collateral than avaliable
+
+
+
 ### PaymentMet
 * Attempted to pay after payment was met.
 
@@ -1124,7 +1129,7 @@ function transferOwnership(address newOwner) external nonpayable
 ### withdrawExcessCollateral
 
 ```solidity
-function withdrawExcessCollateral(address receiver) external nonpayable
+function withdrawExcessCollateral(uint256 amount, address receiver) external nonpayable
 ```
 
 The Owner may withdraw excess collateral from bond contract. The number of collateralTokens remaining in the contract must be enough to cover the total supply of Bonds in accordance to both the collateralRatio and convertibleRatio.
@@ -1132,6 +1137,12 @@ The Owner may withdraw excess collateral from bond contract. The number of colla
 #### Parameters
 
 <table>
+  <tr>
+    <td>uint256 </td>
+    <td>amount</td>
+        <td>
+    The amount of collateral to withdraw. Reverts if this number is greater than avaliable.     </td>
+      </tr>
   <tr>
     <td>address </td>
     <td>receiver</td>

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -228,6 +228,11 @@ Emitted when a token is swept by the contract owner.
 
 
 
+### NotEnoughCollateral
+* Attempted to withdraw more collateral than avaliable
+
+
+
 ### PaymentMet
 * Attempted to pay after payment was met.
 
@@ -734,7 +739,7 @@ Sends tokens to the owner that are in this contract.
 ### withdrawExcessCollateral
 
 ```solidity
-function withdrawExcessCollateral(address receiver) external nonpayable
+function withdrawExcessCollateral(uint256 amount, address receiver) external nonpayable
 ```
 
 The Owner may withdraw excess collateral from bond contract. The number of collateralTokens remaining in the contract must be enough to cover the total supply of Bonds in accordance to both the collateralRatio and convertibleRatio.
@@ -742,6 +747,12 @@ The Owner may withdraw excess collateral from bond contract. The number of colla
 #### Parameters
 
 <table>
+  <tr>
+    <td>uint256 </td>
+    <td>amount</td>
+        <td>
+    The amount of collateral to withdraw. Reverts if this number is greater than avaliable.     </td>
+      </tr>
   <tr>
     <td>address </td>
     <td>receiver</td>

--- a/docs/interfaces/IBondFactory.md
+++ b/docs/interfaces/IBondFactory.md
@@ -35,7 +35,7 @@ Emitted when a new bond is created.
     <td>address <code>indexed</code></td>
     <td>owner</td>
         <td>
-    Ownership of the created Bond is transferred to this address by way of _transferOwnership and tokens are minted to this address. See `initialize` in `Bond`.    </td>
+    Ownership of the created Bond is transferred to this address by way of _transfeOwnership and tokens are minted to this address. See `initialize` in `Bond`.    </td>
       </tr>
   <tr>
     <td>uint256 </td>

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -45,7 +45,7 @@ const DECIMALS_TO_TEST = [6, 8, 18];
   Recommended to use your editors "fold all" and unfolding the test of interest.
   "command / ctrl + k" -> "command / ctrl 0" for Visual Studio Code
 */
-describe.only("Bond", () => {
+describe("Bond", () => {
   // owner deploys and is the "issuer"
   let owner: SignerWithAddress;
   // bondHolder is one who has the bonds and will redeem or convert them
@@ -422,7 +422,7 @@ describe.only("Bond", () => {
                 config.collateralTokenAmount.div(2)
               );
             });
-            it.only("fails if requesting too much", async () => {
+            it("fails if requesting too much", async () => {
               const owed = await bond.amountOwed();
               await paymentToken.approve(bond.address, owed);
               await bond.pay(owed);

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -424,7 +424,11 @@ describe.only("Bond", () => {
               expect(await bond.totalSupply()).to.not.equal(0);
 
               await expectTokenDelta(
-                () => bond.withdrawExcessCollateral(owner.address),
+                async () =>
+                  bond.withdrawExcessCollateral(
+                    await bond.previewWithdraw(0),
+                    owner.address
+                  ),
                 collateralToken,
                 owner,
                 bond.address,
@@ -489,25 +493,30 @@ describe.only("Bond", () => {
               ).wait();
               await (await bond.pay(targetPayment)).wait();
               const amountOwed = await bond.amountOwed();
-              await (await bond.withdrawExcessCollateral(owner.address)).wait();
+              await (
+                await bond.withdrawExcessCollateral(
+                  await bond.previewWithdraw(0),
+                  owner.address
+                )
+              ).wait();
               expect(await bond.amountOwed()).to.be.equal(amountOwed);
             });
 
             // it("should revert when called by non-withdrawer", async () => {
             //   await expect(
-            //     bond.connect(attacker).withdrawExcessCollateral()
+            //     bond.connect(attacker).withdrawExcessCollateral(await bond.previewWithdraw(0), )
             //   ).to.be.revertedWith(
             //     `AccessControl: account ${attacker.address.toLowerCase()} is missing role ${withdrawRole}`
             //   );
             // });
 
             // it("should grant and revoke withdraw role", async () => {
-            //   await expect(bond.connect(attacker).withdrawExcessCollateral()).to
+            //   await expect(bond.connect(attacker).withdrawExcessCollateral(await bond.previewWithdraw(0), )).to
             //     .not.be.reverted;
 
             //   await bond.revokeRole(withdrawRole, attacker.address);
             //   await expect(
-            //     bond.connect(attacker).withdrawExcessCollateral()
+            //     bond.connect(attacker).withdrawExcessCollateral(await bond.previewWithdraw(0), )
             //   ).to.be.revertedWith(
             //     `AccessControl: account ${attacker.address.toLowerCase()} is missing role ${withdrawRole}`
             //   );
@@ -570,7 +579,11 @@ describe.only("Bond", () => {
               await bond.burn(config.maxSupply);
               expect(await bond.totalSupply()).to.equal(0);
               await expectTokenDelta(
-                () => bond.withdrawExcessCollateral(owner.address),
+                async () =>
+                  bond.withdrawExcessCollateral(
+                    await bond.previewWithdraw(0),
+                    owner.address
+                  ),
                 collateralToken,
                 owner,
                 owner.address,


### PR DESCRIPTION
<img width="355" alt="image" src="https://user-images.githubusercontent.com/15036618/163278264-4d7ba27e-e1ba-4328-907f-e96b7e696447.png">

This change is to support the withdraw panel. Previously it was only possible to withdraw 100% of the available collateral. 

This method will also be called in the future for refinancing. 