### PR TITLE
create simpler previewWithdraw method

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -115,7 +115,7 @@ contract Bond is
         external
         onlyOwner
     {
-        if (amount > previewWithdraw(0)) {
+        if (amount > previewWithdraw()) {
             revert NotEnoughCollateral();
         }
 
@@ -232,8 +232,11 @@ contract Bond is
         collateralTokens = bonds.mulWadDown(convertibleRatio);
     }
 
-    /// @inheritdoc IBond
-    function previewWithdraw(uint256 payment)
+    function previewWithdraw() public view returns (uint256 collateralTokens) {
+        collateralTokens = previewWithdrawAfterPayment(0);
+    }
+
+    function previewWithdrawAfterPayment(uint256 payment)
         public
         view
         returns (uint256 collateralTokens)

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -232,10 +232,12 @@ contract Bond is
         collateralTokens = bonds.mulWadDown(convertibleRatio);
     }
 
+    /// @inheritdoc IBond
     function previewWithdraw() public view returns (uint256 collateralTokens) {
         collateralTokens = previewWithdrawAfterPayment(0);
     }
 
+    /// @inheritdoc IBond
     function previewWithdrawAfterPayment(uint256 payment)
         public
         view

--- a/contracts/echidna/TestBond.sol
+++ b/contracts/echidna/TestBond.sol
@@ -113,7 +113,7 @@ contract TestBond {
 
     function withdrawExcessCollateral() public {
         try
-            bond.withdrawExcessCollateral(bond.previewWithdraw(0), msg.sender)
+            bond.withdrawExcessCollateral(bond.previewWithdraw(), msg.sender)
         {} catch Error(string memory reason) {
             emit AssertionFailed(reason);
         }

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -301,7 +301,15 @@ interface IBond {
         view
         returns (uint256 collateralTokens);
 
-    // @notice Calls previewWithdrawAfterPayment with a payment amount of 0
+    /**
+        @notice The amount of collateral that the issuer would be able to 
+            withdraw from the contract. This does not take into account an
+            amount of payment like `previewWithdrawAfterPayment` does. See that
+            function for more information.
+        @dev Calls `previewWithdrawAfterPayment` with a payment amount of 0.
+        @return collateralTokens The number of collateralTokens that would be
+        received by the issuer.
+    */
     function previewWithdraw() external view returns (uint256 collateralTokens);
 
     /**

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -293,13 +293,9 @@ interface IBond {
             bond is NOT paid AND mature (Defaulted)
                 to cover collateralRatio: totalUncoveredSupply * collateralRatio
                 to cover convertibleRatio: 0
-        @param payment The amount of paymentToken to add when previewing a withdraw.
         @return collateralTokens The number of collateralTokens received.
      */
-    function previewWithdraw(uint256 payment)
-        external
-        view
-        returns (uint256 collateralTokens);
+    function previewWithdraw() external view returns (uint256 collateralTokens);
 
     /**
         @notice The Bond holder can burn Bonds in return for their portion of

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -293,8 +293,15 @@ interface IBond {
             bond is NOT paid AND mature (Defaulted)
                 to cover collateralRatio: totalUncoveredSupply * collateralRatio
                 to cover convertibleRatio: 0
+        @param payment The amount of paymentToken to add when previewing a withdraw.
         @return collateralTokens The number of collateralTokens received.
      */
+    function previewWithdrawAfterPayment(uint256 payment)
+        external
+        view
+        returns (uint256 collateralTokens);
+
+    // @notice Calls previewWithdrawAfterPayment with a payment amount of 0
     function previewWithdraw() external view returns (uint256 collateralTokens);
 
     /**

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -922,21 +922,11 @@ At maturity, if the given bonds are redeemed, this would be the amount of collat
 ### previewWithdraw
 
 ```solidity
-function previewWithdraw(uint256 payment) external view returns (uint256 collateralTokens)
+function previewWithdraw() external view returns (uint256 collateralTokens)
 ```
 
 The amount of collateral that the issuer would be able to  withdraw from the contract. This function rounds up the number  of collateralTokens required in the contract and therefore may round down the amount received.
 
-#### Parameters
-
-<table>
-  <tr>
-    <td>uint256 </td>
-    <td>payment</td>
-        <td>
-    The amount of paymentToken to add when previewing a withdraw.    </td>
-      </tr>
-</table>
 
 #### Returns
 
@@ -947,6 +937,33 @@ The amount of collateral that the issuer would be able to  withdraw from the con
       uint256    </td>
         <td>
     The number of collateralTokens received.    </td>
+      </tr>
+</table>
+
+### previewWithdrawAfterPayment
+
+```solidity
+function previewWithdrawAfterPayment(uint256 payment) external view returns (uint256 collateralTokens)
+```
+
+
+
+#### Parameters
+
+<table>
+  <tr>
+    <td>uint256 </td>
+    <td>payment</td>
+      </tr>
+</table>
+
+#### Returns
+
+
+<table>
+  <tr>
+    <td>
+      uint256    </td>
       </tr>
 </table>
 

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -925,8 +925,37 @@ At maturity, if the given bonds are redeemed, this would be the amount of collat
 function previewWithdraw() external view returns (uint256 collateralTokens)
 ```
 
+
+
+
+#### Returns
+
+
+<table>
+  <tr>
+    <td>
+      uint256    </td>
+      </tr>
+</table>
+
+### previewWithdrawAfterPayment
+
+```solidity
+function previewWithdrawAfterPayment(uint256 payment) external view returns (uint256 collateralTokens)
+```
+
 The amount of collateral that the issuer would be able to  withdraw from the contract. This function rounds up the number  of collateralTokens required in the contract and therefore may round down the amount received.
 
+#### Parameters
+
+<table>
+  <tr>
+    <td>uint256 </td>
+    <td>payment</td>
+        <td>
+    The amount of paymentToken to add when previewing a withdraw.    </td>
+      </tr>
+</table>
 
 #### Returns
 
@@ -937,33 +966,6 @@ The amount of collateral that the issuer would be able to  withdraw from the con
       uint256    </td>
         <td>
     The number of collateralTokens received.    </td>
-      </tr>
-</table>
-
-### previewWithdrawAfterPayment
-
-```solidity
-function previewWithdrawAfterPayment(uint256 payment) external view returns (uint256 collateralTokens)
-```
-
-
-
-#### Parameters
-
-<table>
-  <tr>
-    <td>uint256 </td>
-    <td>payment</td>
-      </tr>
-</table>
-
-#### Returns
-
-
-<table>
-  <tr>
-    <td>
-      uint256    </td>
       </tr>
 </table>
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -662,21 +662,11 @@ At maturity, if the given bonds are redeemed, this would be the amount of collat
 ### previewWithdraw
 
 ```solidity
-function previewWithdraw(uint256 payment) external view returns (uint256 collateralTokens)
+function previewWithdraw() external view returns (uint256 collateralTokens)
 ```
 
 The amount of collateral that the issuer would be able to  withdraw from the contract. This function rounds up the number  of collateralTokens required in the contract and therefore may round down the amount received.
 
-#### Parameters
-
-<table>
-  <tr>
-    <td>uint256 </td>
-    <td>payment</td>
-        <td>
-    The amount of paymentToken to add when previewing a withdraw.    </td>
-      </tr>
-</table>
 
 #### Returns
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -665,8 +665,37 @@ At maturity, if the given bonds are redeemed, this would be the amount of collat
 function previewWithdraw() external view returns (uint256 collateralTokens)
 ```
 
+
+
+
+#### Returns
+
+
+<table>
+  <tr>
+    <td>
+      uint256    </td>
+      </tr>
+</table>
+
+### previewWithdrawAfterPayment
+
+```solidity
+function previewWithdrawAfterPayment(uint256 payment) external view returns (uint256 collateralTokens)
+```
+
 The amount of collateral that the issuer would be able to  withdraw from the contract. This function rounds up the number  of collateralTokens required in the contract and therefore may round down the amount received.
 
+#### Parameters
+
+<table>
+  <tr>
+    <td>uint256 </td>
+    <td>payment</td>
+        <td>
+    The amount of paymentToken to add when previewing a withdraw.    </td>
+      </tr>
+</table>
 
 #### Returns
 

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -413,7 +413,7 @@ describe("Bond", () => {
               await expectTokenDelta(
                 async () =>
                   bond.withdrawExcessCollateral(
-                    (await bond.previewWithdraw(0)).div(2),
+                    (await bond.previewWithdraw()).div(2),
                     owner.address
                   ),
                 collateralToken,
@@ -429,7 +429,7 @@ describe("Bond", () => {
 
               await expect(
                 bond.withdrawExcessCollateral(
-                  (await bond.previewWithdraw(0)).add(1),
+                  (await bond.previewWithdraw()).add(1),
                   owner.address
                 )
               ).to.be.revertedWith("NotEnoughCollateral");
@@ -456,7 +456,7 @@ describe("Bond", () => {
               await expectTokenDelta(
                 async () =>
                   bond.withdrawExcessCollateral(
-                    await bond.previewWithdraw(0),
+                    await bond.previewWithdraw(),
                     owner.address
                   ),
                 collateralToken,
@@ -525,7 +525,7 @@ describe("Bond", () => {
               const amountOwed = await bond.amountOwed();
               await (
                 await bond.withdrawExcessCollateral(
-                  await bond.previewWithdraw(0),
+                  await bond.previewWithdraw(),
                   owner.address
                 )
               ).wait();
@@ -592,7 +592,7 @@ describe("Bond", () => {
               await expectTokenDelta(
                 async () =>
                   bond.withdrawExcessCollateral(
-                    await bond.previewWithdraw(0),
+                    await bond.previewWithdraw(),
                     owner.address
                   ),
                 collateralToken,
@@ -644,7 +644,7 @@ describe("Bond", () => {
                 bond.address,
                 utils.parseEther("1")
               );
-              expect(await bond.previewWithdraw(0)).to.equal(
+              expect(await bond.previewWithdraw()).to.equal(
                 utils.parseEther("1")
               );
             });

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -107,7 +107,7 @@ export const payAndWithdraw = async ({
 }) => {
   await paymentToken.approve(bond.address, paymentTokenAmount);
   await (await bond.pay(paymentTokenAmount)).wait();
-  expect(await bond.previewWithdraw(0)).to.equal(collateralToReceive);
+  expect(await bond.previewWithdraw()).to.equal(collateralToReceive);
 };
 
 export const burnAndWithdraw = async ({
@@ -120,7 +120,7 @@ export const burnAndWithdraw = async ({
   collateralToReceive: BigNumber;
 }) => {
   await (await bond.burn(sharesToBurn)).wait();
-  expect(await bond.previewWithdraw(0)).to.equal(collateralToReceive);
+  expect(await bond.previewWithdraw()).to.equal(collateralToReceive);
 };
 
 export const redeemAndCheckTokens = async ({


### PR DESCRIPTION
Gas before(top) and after(bottom) this change. CreateBond costs less gas AFTER this change...? How does that make sense? 
Deploying the implementation contract costs a bit more, but we can tank that. 
<img width="940" alt="image" src="https://user-images.githubusercontent.com/15036618/163580660-249b46df-9428-4fc0-b44a-84f719088d26.png">

@Namaskar-1F64F I talked with @Pet3ris  about this today - it may be simpler to users for this to be a separate method. The choice to add it or not is black and white. I'd love to get your thoughts on if we should merge this, or close the PR. You only need to look at the Bond.sol file. 

Note: Interfaces need updated - please ignore those, I'll update them if we want to merge this in. 