### PR TITLE
Remove isFullyPaid

### DIFF
--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -190,12 +190,6 @@ interface IBond {
     ) external;
 
     /**
-        @notice Checks if the balance of paymentToken covers the Bond supply.
-        @return isBondPaid Whether or not the Bond is fully paid.
-    */
-    function isFullyPaid() external view returns (bool isBondPaid);
-
-    /**
         @notice Checks if the maturity timestamp has passed.
         @return isBondMature Whether or not the Bond has reached maturity.
     */

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -1076,40 +1076,6 @@ This one-time setup initiated by the BondFactory initializes the Bond with the g
 
 
 
-### isFullyPaid
-
-
-```solidity
-function isFullyPaid() external view returns (bool isBondPaid)
-
-```
-
-Checks if the balance of paymentToken covers the Bond supply.
-
-
-
-
-
-#### Returns
-
-
-<table>
-
-  <tr>
-    <td>
-      bool
-    </td>
-    
-    <td>
-    Whether or not the Bond is fully paid.
-    </td>
-    
-  </tr>
-
-</table>
-
-
-
 ### isMature
 
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -751,40 +751,6 @@ This one-time setup initiated by the BondFactory initializes the Bond with the g
 
 
 
-### isFullyPaid
-
-
-```solidity
-function isFullyPaid() external view returns (bool isBondPaid)
-
-```
-
-Checks if the balance of paymentToken covers the Bond supply.
-
-
-
-
-
-#### Returns
-
-
-<table>
-
-  <tr>
-    <td>
-      bool
-    </td>
-    
-    <td>
-    Whether or not the Bond is fully paid.
-    </td>
-    
-  </tr>
-
-</table>
-
-
-
 ### isMature
 
 


### PR DESCRIPTION
The functionality of `isFullyPaid` was duplicated by the function `amountOwed`. The calculation if the bond is fully paid or not is equivalent to checking if the amount owed is 0.


```
isFullyPaid() == (amountOwed() == 0)
```

closes #250