### PR TITLE
Documentation updates

### DIFF
--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -153,8 +153,8 @@ contract BondFactory is IBondFactory, AccessControl {
             maturity,
             paymentToken,
             collateralToken,
-            collateralRatio,
-            convertibleRatio,
+            collateralTokenAmount,
+            convertibleTokenAmount,
             bonds
         );
     }

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -163,7 +163,9 @@ interface IBond {
             Bond with the given configuration.
         @dev New Bond contract deployed via clone. See `BondFactory`.
         @dev During initialization, __Ownable_init is not called because the
-            owner, or `bondOwner`, is not necessarily the `msg.sender`. Nor is __ERC20Burnable_init called because it generates an empty function.
+            owner would be set to the BondFactory's Address. Additionally,
+            __ERC20Burnable_init is not called because it generates an empty
+            function.
         @param bondName Passed into the ERC20 token to define the name.
         @param bondSymbol Passed into the ERC20 token to define the symbol.
         @param bondOwner Ownership of the created Bond is transferred to this

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -162,11 +162,11 @@ interface IBond {
         @notice This one-time setup initiated by the BondFactory initializes the
             Bond with the given configuration.
         @dev New Bond contract deployed via clone. See `BondFactory`.
-        @dev Not calling __AccessControl_init or __ERC20Burnable_init here since
-            they currently generate an empty function.
+        @dev During initialization, __Ownable_init is not called because the
+            owner, or `bondOwner`, is not necessarily the `msg.sender`. Nor is __ERC20Burnable_init called because it generates an empty function.
         @param bondName Passed into the ERC20 token to define the name.
         @param bondSymbol Passed into the ERC20 token to define the symbol.
-        @param owner Ownership of the created Bond is transferred to this
+        @param bondOwner Ownership of the created Bond is transferred to this
             address by way of _transferOwnership and also the address that
             tokens are minted to. See `initialize` in `Bond`.
         @param _maturity The timestamp at which the Bond will mature.
@@ -180,7 +180,7 @@ interface IBond {
     function initialize(
         string memory bondName,
         string memory bondSymbol,
-        address owner,
+        address bondOwner,
         uint256 _maturity,
         address _paymentToken,
         address _collateralToken,
@@ -338,10 +338,10 @@ interface IBond {
         @notice Sends ERC20 tokens to the owner that are in this contract.
         @dev The collateralToken and paymentToken cannot be swept. Emits 
             `TokenSweep` event.
-        @param token The ERC20 token to sweep and send to the owner.
+        @param sweepingToken The ERC20 token to sweep and send to the receiver.
         @param receiver The address that is transferred the swept token.
     */
-    function sweep(IERC20Metadata token, address receiver) external;
+    function sweep(IERC20Metadata sweepingToken, address receiver) external;
 
     /**
         @notice The Owner may withdraw excess collateral from the Bond contract.

--- a/contracts/interfaces/IBondFactory.sol
+++ b/contracts/interfaces/IBondFactory.sol
@@ -108,8 +108,9 @@ interface IBondFactory {
     function isTokenAllowListEnabled() external view returns (bool isEnabled);
 
     /**
-        @notice Check if the address was created by this Bond factory.
-        @dev This is used to check if a bond was issued by this contract
+        @notice Returns whether or not the given address key is a bond created
+            by this Bond factory.
+        @dev This mapping is used to check if a bond was issued by this contract
             on-chain. For example, if we want to make a new contract that
             accepts any issued Bonds and exchanges them for new Bonds, the
             exchange contract would need a way to know that the Bonds are owned


### PR DESCRIPTION
```
BondFactory
- event BondCreated() variable namings missmatch from interface to actual contract.
  Fixed by sending tokenAmounts

- isBond(): Implemented as actual mapping in the contract. The documentation in the interface states that this is a function instead of the actual mapping
  Fixed by updating natspec

- isTokenAllowListEnabled(): Implemented as a boolean in the contract.
- tokenImplementation(): Implemented as immutable address in the contract.
- isIssuerAllowListEnabled(): Implemented as a boolean in the contract.
  Won't fix as keeping the documentation in the interface is more clear.

Bond
- function initialize(has owner param in interface vs bondOwner in contract)
  Fixed by using bondOwner in interface
- function sweep() has same issue as line above^ 
  Fixed by using sweepingToken in the interface.
- removed accessControl and replaced it with OwnerUpgradable but there are still notes about access control in IBond for the initialize function on L165.
  Updated the natspec

- collateralToken(): Implemented as public address
- convertibleRatio(): Implemented as public uint
- maturity(): Implemented as public uint
- paymentToken(): Implemented as public address
  Won't fix as keeping the documentation in the interface is more clear.
```
closes #255 