### PR TITLE
Zellic Audit Fixes

### DIFF
--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -302,9 +302,10 @@ interface IBond {
     /**
         @notice The number of collateralTokens that the owner would be able to 
             withdraw from the contract. This does not take into account an
-            amount of payment like `previewWithdrawAfterPayment` does. See that
-            function for more information.
-        @dev Calls `previewWithdrawAfterPayment` with a payment amount of 0.
+            amount of payment like `previewWithdrawExcessCollateralAfterPayment`
+            does. See that function for more information.
+        @dev Calls `previewWithdrawExcessCollateralAfterPayment` with a payment
+            amount of 0.
         @return collateralTokens The number of collateralTokens that would be
             withdrawn.
     */

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -629,6 +629,8 @@ This one-time setup initiated by the BondFactory initializes the Bond with the g
   <tr>
     <td>address </td>
     <td>bondOwner</td>
+        <td>
+    Ownership of the created Bond is transferred to this address by way of _transferOwnership and also the address that tokens are minted to. See `initialize` in `Bond`.    </td>
       </tr>
   <tr>
     <td>uint256 </td>
@@ -885,7 +887,7 @@ At maturity, if the given bond shares are redeemed, this would be the number of 
 function previewWithdrawExcessCollateral() external view returns (uint256 collateralTokens)
 ```
 
-The number of collateralTokens that the owner would be able to  withdraw from the contract. This does not take into account an amount of payment like `previewWithdrawAfterPayment` does. See that function for more information.
+The number of collateralTokens that the owner would be able to  withdraw from the contract. This does not take into account an amount of payment like `previewWithdrawExcessCollateralAfterPayment` does. See that function for more information.
 
 
 #### Returns
@@ -996,6 +998,8 @@ Sends ERC20 tokens to the owner that are in this contract.
   <tr>
     <td>contract IERC20Metadata </td>
     <td>sweepingToken</td>
+        <td>
+    The ERC20 token to sweep and send to the receiver.    </td>
       </tr>
   <tr>
     <td>address </td>

--- a/docs/BondFactory.md
+++ b/docs/BondFactory.md
@@ -405,7 +405,7 @@ function hasRole(bytes32 role, address account) external view returns (bool)
 function isBond(address) external view returns (bool)
 ```
 
-Check if the address was created by this Bond factory.
+Returns whether or not the given address key is a bond created by this Bond factory.
 
 #### Parameters
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -382,7 +382,7 @@ The number of convertibleTokens the bonds will convert into.
 ### initialize
 
 ```solidity
-function initialize(string bondName, string bondSymbol, address owner, uint256 _maturity, address _paymentToken, address _collateralToken, uint256 _collateralRatio, uint256 _convertibleRatio, uint256 maxSupply) external nonpayable
+function initialize(string bondName, string bondSymbol, address bondOwner, uint256 _maturity, address _paymentToken, address _collateralToken, uint256 _collateralRatio, uint256 _convertibleRatio, uint256 maxSupply) external nonpayable
 ```
 
 This one-time setup initiated by the BondFactory initializes the Bond with the given configuration.
@@ -404,7 +404,7 @@ This one-time setup initiated by the BondFactory initializes the Bond with the g
       </tr>
   <tr>
     <td>address </td>
-    <td>owner</td>
+    <td>bondOwner</td>
         <td>
     Ownership of the created Bond is transferred to this address by way of _transferOwnership and also the address that tokens are minted to. See `initialize` in `Bond`.    </td>
       </tr>
@@ -625,7 +625,7 @@ At maturity, if the given bond shares are redeemed, this would be the number of 
 function previewWithdrawExcessCollateral() external view returns (uint256 collateralTokens)
 ```
 
-The number of collateralTokens that the owner would be able to  withdraw from the contract. This does not take into account an amount of payment like `previewWithdrawAfterPayment` does. See that function for more information.
+The number of collateralTokens that the owner would be able to  withdraw from the contract. This does not take into account an amount of payment like `previewWithdrawExcessCollateralAfterPayment` does. See that function for more information.
 
 
 #### Returns
@@ -715,7 +715,7 @@ The Bond holder can burn bond shares in return for their portion of paymentToken
 ### sweep
 
 ```solidity
-function sweep(contract IERC20Metadata token, address receiver) external nonpayable
+function sweep(contract IERC20Metadata sweepingToken, address receiver) external nonpayable
 ```
 
 Sends ERC20 tokens to the owner that are in this contract.
@@ -725,9 +725,9 @@ Sends ERC20 tokens to the owner that are in this contract.
 <table>
   <tr>
     <td>contract IERC20Metadata </td>
-    <td>token</td>
+    <td>sweepingToken</td>
         <td>
-    The ERC20 token to sweep and send to the owner.    </td>
+    The ERC20 token to sweep and send to the receiver.    </td>
       </tr>
   <tr>
     <td>address </td>

--- a/docs/interfaces/IBondFactory.md
+++ b/docs/interfaces/IBondFactory.md
@@ -226,7 +226,7 @@ Creates a new Bond. The calculated ratios are rounded down.
 function isBond(address) external view returns (bool)
 ```
 
-Check if the address was created by this Bond factory.
+Returns whether or not the given address key is a bond created by this Bond factory.
 
 #### Parameters
 

--- a/spec/stateMachine.md
+++ b/spec/stateMachine.md
@@ -17,7 +17,7 @@
 
 ## Not fully paid and matured (Defaulted)
 
-- Anyone can fully pay and move to "Not fully paid and matured"
+- Anyone can fully pay and move to "Fully paid and matured"
 
 ## Fully paid and matured (Paid)
 


### PR DESCRIPTION
```
- IBond.sol - L303 & 305 reference `previewWithdrawAfterPayment` which no longer exists. This should be updated to `previewWithdrawExcessCollateralAfterPayment`

- https://github.com/porter-finance/v1-core/blob/main/spec/stateMachine.md#not-fully-paid-and-matured-defaulted

I think this should be "Anyone can fully pay and move to fully paid and matured"
```

Additionally, I've added tests to get up to 100% coverage.

<img width="1016" alt="CleanShot 2022-04-26 at 12 23 03@2x" src="https://user-images.githubusercontent.com/7458951/165347200-04e67f52-c42a-44c9-82f3-18f4d421f645.png">
