### PR TITLE
Fix deployment scripts

### DIFF
--- a/deploy/integrate_create_auctions.ts
+++ b/deploy/integrate_create_auctions.ts
@@ -2,7 +2,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import {
   deploymentBonds,
   easyAuctionAbi,
-  mumbaiGnosis,
+  rinkebyGnosis,
 } from "../test/constants";
 import { Bond, TestERC20 } from "../typechain";
 import { BondConfigType } from "../test/interfaces";
@@ -45,7 +45,7 @@ module.exports = async function ({
     );
     const { address } = await deployments.get(bondSymbol);
     const bond = (await ethers.getContractAt("Bond", address)) as Bond;
-    const auction = await ethers.getContractAt(easyAuctionAbi, mumbaiGnosis);
+    const auction = await ethers.getContractAt(easyAuctionAbi, rinkebyGnosis);
     const signer = await ethers.getSigner(deployer);
     try {
       if ((await paymentToken.allowance(deployer, auction.address)).eq(0)) {
@@ -98,8 +98,9 @@ auctionEndDate: ${auctionEndDate}
         auctionData,
         biddingToken: paymentToken,
         auctioningToken: bond,
-        sellAmount: (800_000_000).toString(),
-        minBuyAmount: (100_000_000).toString(),
+        // the price is sellAmount/buyAmount so ~9000/1000 = .9 each
+        sellAmount: (9_000).toString(),
+        minBuyAmount: (10_000).toString(),
         nrOfOrders,
       });
     } catch (e) {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,6 +38,7 @@ const config: HardhatUserConfig = {
         auto: false,
         interval: 10,
       },
+      gasMultiplier: 2,
       url: `https://eth-rinkeby.alchemyapi.io/v2/${process.env.ALCHEMY_KEY}`,
       accounts:
         process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],

--- a/tasks/settleAuction.ts
+++ b/tasks/settleAuction.ts
@@ -1,12 +1,12 @@
 import { task } from "hardhat/config";
-import { easyAuctionAbi, mumbaiGnosis } from "../test/constants";
+import { easyAuctionAbi, rinkebyGnosis } from "../test/constants";
 import { Bond } from "../typechain";
 
 task("settle-auction", "Settles auction if it can be settled.")
   .addParam("auctionId", "The ID of the auction to settle.")
   .setAction(async ({ auctionId }, hre) => {
     const { ethers } = hre;
-    const auction = await ethers.getContractAt(easyAuctionAbi, mumbaiGnosis);
+    const auction = await ethers.getContractAt(easyAuctionAbi, rinkebyGnosis);
     try {
       const auctionData = await auction.auctionData(auctionId);
       const { auctioningToken, auctionEndDate } = auctionData;


### PR DESCRIPTION
* Doubles the gas used from the estimates. This seems like it solved the issue with transactions getting stuck in the mempool. 
* Use rinkeby everywhere instead of polygon
* Use realistic bid amounts

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/15036618/166483092-d30b025c-b976-476b-875c-36564f93f44b.png">
<img width="910" alt="image" src="https://user-images.githubusercontent.com/15036618/166487089-36a7a036-7e2c-4d63-803e-0a97dc335481.png">
