### PR TITLE
add maturity period logic

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -70,7 +70,7 @@ contract Bond is
     */
     modifier afterGracePeriodOrPaid() {
         if (beforeGracePeriodEnd() && amountUnpaid() != 0) {
-            revert BondNotYetMaturedOrPaid();
+            revert BondNotYetAfterGracePeriodOrPaid();
         }
         _;
     }

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -69,10 +69,11 @@ contract Bond is
             redeemed when either the bond is fully paid or mature.
     */
     modifier afterGracePeriodOrPaid() {
-        if (!isAfterGracePeriod() && amountUnpaid() != 0) {
-            revert BondNotYetAfterGracePeriodOrPaid();
+        if (isAfterGracePeriod() || amountUnpaid() == 0) {
+            _;
+        } else {
+            revert BondBeforeGracePeriodOrPaid();
         }
-        _;
     }
 
     /// @inheritdoc IBond

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -403,6 +403,11 @@ contract Bond is
         isBondMature = block.timestamp >= maturity;
     }
 
+    /// @inheritdoc IERC20MetadataUpgradeable
+    function decimals() public view override returns (uint8) {
+        return IERC20Metadata(paymentToken).decimals();
+    }
+
     /**
         @notice Checks if the grace period timestamp has passed.
         @return isGracePeriodOver Whether or not the Bond is passed the grace period
@@ -413,11 +418,6 @@ contract Bond is
         returns (bool isGracePeriodOver)
     {
         isGracePeriodOver = block.timestamp >= gracePeriodEnd();
-    }
-
-    /// @inheritdoc IERC20MetadataUpgradeable
-    function decimals() public view override returns (uint8) {
-        return IERC20Metadata(paymentToken).decimals();
     }
 
     function _max(uint256 a, uint256 b) internal pure returns (uint256) {

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -34,11 +34,10 @@ contract Bond is
     using SafeERC20 for IERC20Metadata;
     using FixedPointMathLib for uint256;
 
-    /// @notice How long until after maturity date
-    uint256 internal constant GRACE_PERIOD = 7 days;
-
     /// @inheritdoc IBond
     uint256 public maturity;
+
+    uint256 public gracePeriodEnd;
 
     /// @inheritdoc IBond
     address public paymentToken;
@@ -92,6 +91,7 @@ contract Bond is
         _transferOwnership(bondOwner);
 
         maturity = _maturity;
+        gracePeriodEnd = _maturity + 7 days;
         paymentToken = _paymentToken;
         collateralToken = _collateralToken;
         collateralRatio = _collateralRatio;
@@ -394,12 +394,8 @@ contract Bond is
         isBondMature = block.timestamp >= maturity;
     }
 
-    function beforeGracePeriodEnd()
-        internal
-        view
-        returns (bool isBondInGracePeriod)
-    {
-        isBondInGracePeriod = block.timestamp < maturity + GRACE_PERIOD;
+    function beforeGracePeriodEnd() internal view returns (bool isGracePeriod) {
+        isGracePeriod = block.timestamp < gracePeriodEnd;
     }
 
     /// @inheritdoc IERC20MetadataUpgradeable

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -37,6 +37,7 @@ contract Bond is
     /// @inheritdoc IBond
     uint256 public maturity;
 
+    /// @inheritdoc IBond
     uint256 public gracePeriodEnd;
 
     /// @inheritdoc IBond
@@ -69,7 +70,7 @@ contract Bond is
             redeemed when either the bond is fully paid or mature.
     */
     modifier afterGracePeriodOrPaid() {
-        if (beforeGracePeriodEnd() && amountUnpaid() != 0) {
+        if (!isAfterGracePeriod() && amountUnpaid() != 0) {
             revert BondNotYetAfterGracePeriodOrPaid();
         }
         _;
@@ -394,8 +395,16 @@ contract Bond is
         isBondMature = block.timestamp >= maturity;
     }
 
-    function beforeGracePeriodEnd() internal view returns (bool isGracePeriod) {
-        isGracePeriod = block.timestamp < gracePeriodEnd;
+    /**
+        @notice Checks if the grace period timestamp has passed.
+        @return isGracePeriodOver Whether or not the Bond is passed the grace period
+    */
+    function isAfterGracePeriod()
+        internal
+        view
+        returns (bool isGracePeriodOver)
+    {
+        isGracePeriodOver = block.timestamp >= gracePeriodEnd;
     }
 
     /// @inheritdoc IERC20MetadataUpgradeable

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -34,6 +34,12 @@ contract Bond is
     using SafeERC20 for IERC20Metadata;
     using FixedPointMathLib for uint256;
 
+    /**
+        @notice A period of time after maturity in which bond redemption is
+            disallowed for non fully paid bonds. This restriction is lifted 
+            once the grace period has ended. The issuer has the ability to
+            pay during this time to fully pay the bond. 
+    */
     uint256 internal constant GRACE_PERIOD = 7 days;
 
     /// @inheritdoc IBond
@@ -64,9 +70,9 @@ contract Bond is
     }
 
     /**
-        @dev Confirms that the Bond is either mature or has been paid.
+        @dev Confirms that the Bond is after the grace period or has been paid.
             This is used in the `redeem` function because bond shares can be
-            redeemed when either the bond is fully paid or mature.
+            redeemed when the Bond is fully paid or past the grace period.
     */
     modifier afterGracePeriodOrPaid() {
         if (isAfterGracePeriod() || amountUnpaid() == 0) {
@@ -410,7 +416,8 @@ contract Bond is
 
     /**
         @notice Checks if the grace period timestamp has passed.
-        @return isGracePeriodOver Whether or not the Bond is passed the grace period
+        @return isGracePeriodOver Whether or not the Bond is past the
+            grace period.
     */
     function isAfterGracePeriod()
         internal

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -34,11 +34,10 @@ contract Bond is
     using SafeERC20 for IERC20Metadata;
     using FixedPointMathLib for uint256;
 
-    /// @inheritdoc IBond
-    uint256 public maturity;
+    uint256 internal constant GRACE_PERIOD = 7 days;
 
     /// @inheritdoc IBond
-    uint256 public gracePeriodEnd;
+    uint256 public maturity;
 
     /// @inheritdoc IBond
     address public paymentToken;
@@ -92,7 +91,6 @@ contract Bond is
         _transferOwnership(bondOwner);
 
         maturity = _maturity;
-        gracePeriodEnd = _maturity + 7 days;
         paymentToken = _paymentToken;
         collateralToken = _collateralToken;
         collateralRatio = _collateralRatio;
@@ -144,6 +142,15 @@ contract Bond is
         );
 
         emit Payment(_msgSender(), amount);
+    }
+
+    /// @inheritdoc IBond
+    function gracePeriodEnd()
+        public
+        view
+        returns (uint256 gracePeriodEndTimestamp)
+    {
+        gracePeriodEndTimestamp = maturity + GRACE_PERIOD;
     }
 
     /// @inheritdoc IBond
@@ -404,7 +411,7 @@ contract Bond is
         view
         returns (bool isGracePeriodOver)
     {
-        isGracePeriodOver = block.timestamp >= gracePeriodEnd;
+        isGracePeriodOver = block.timestamp >= gracePeriodEnd();
     }
 
     /// @inheritdoc IERC20MetadataUpgradeable

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -7,8 +7,8 @@ interface IBond {
     /// @notice Operation restricted because the Bond has matured.
     error BondPastMaturity();
 
-    /// @notice Operation restricted because the Bond has not matured or paid.
-    error BondNotYetMaturedOrPaid();
+    /// @notice Operation restricted because the Bond has after the grace period or paid.
+    error BondNotYetAfterGracePeriodOrPaid();
 
     /// @notice Attempted to pay after payment was met.
     error PaymentAlreadyMet();

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -207,6 +207,12 @@ interface IBond {
     function maturity() external view returns (uint256);
 
     /**
+        @notice One week after the maturity date. Bond collateral can be redeemed after this date.
+        @return The grace period end date as a timestamp. This is always one week after the maturity date
+    */
+    function gracePeriodEnd() external view returns (uint256);
+
+    /**
         @notice Allows the owner to pay the bond by depositing paymentTokens.
         @dev Emits `Payment` event.
         @param amount The number of paymentTokens to deposit.

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -25,9 +25,6 @@ interface IBond {
     /// @notice Attempted to withdraw more collateral than available.
     error NotEnoughCollateral();
 
-    /// @notice Bonds can not be redeemed during the grace period
-    error CurrentlyGracePeriod();
-
     /**
         @notice Emitted when bond shares are converted by a Bond holder.
         @param from The address converting their tokens.

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -7,8 +7,11 @@ interface IBond {
     /// @notice Operation restricted because the Bond has matured.
     error BondPastMaturity();
 
-    /// @notice Operation restricted because the Bond has after the grace period or paid.
-    error BondNotYetAfterGracePeriodOrPaid();
+    /**
+        @notice Bond redemption is impossible because the grace period has not
+            yet passed or the bond has not been fully paid.
+    */
+    error BondBeforeGracePeriodOrPaid();
 
     /// @notice Attempted to pay after payment was met.
     error PaymentAlreadyMet();

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -25,6 +25,9 @@ interface IBond {
     /// @notice Attempted to withdraw more collateral than available.
     error NotEnoughCollateral();
 
+    /// @notice Bonds can not be redeemed during the grace period
+    error CurrentlyGracePeriod();
+
     /**
         @notice Emitted when bond shares are converted by a Bond holder.
         @param from The address converting their tokens.

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -207,10 +207,15 @@ interface IBond {
     function maturity() external view returns (uint256);
 
     /**
-        @notice One week after the maturity date. Bond collateral can be redeemed after this date.
-        @return The grace period end date as a timestamp. This is always one week after the maturity date
+        @notice One week after the maturity date. Bond collateral can be 
+            redeemed after this date.
+        @return gracePeriodEndTimestamp The grace period end date as 
+            a timestamp. This is always one week after the maturity date
     */
-    function gracePeriodEnd() external view returns (uint256);
+    function gracePeriodEnd()
+        external
+        view
+        returns (uint256 gracePeriodEndTimestamp);
 
     /**
         @notice Allows the owner to pay the bond by depositing paymentTokens.

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -583,7 +583,7 @@ function decreaseAllowance(address spender, uint256 subtractedValue) external no
 function gracePeriodEnd() external view returns (uint256)
 ```
 
-
+One week after the maturity date. Bond collateral can be redeemed after this date.
 
 
 #### Returns
@@ -593,6 +593,8 @@ function gracePeriodEnd() external view returns (uint256)
   <tr>
     <td>
       uint256    </td>
+        <td>
+    The grace period end date as a timestamp. This is always one week after the maturity date    </td>
       </tr>
 </table>
 

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -580,10 +580,10 @@ function decreaseAllowance(address spender, uint256 subtractedValue) external no
 ### gracePeriodEnd
 
 ```solidity
-function gracePeriodEnd() external view returns (uint256)
+function gracePeriodEnd() external view returns (uint256 gracePeriodEndTimestamp)
 ```
 
-One week after the maturity date. Bond collateral can be redeemed after this date.
+One week after the maturity date. Bond collateral can be  redeemed after this date.
 
 
 #### Returns
@@ -594,7 +594,7 @@ One week after the maturity date. Bond collateral can be redeemed after this dat
     <td>
       uint256    </td>
         <td>
-    The grace period end date as a timestamp. This is always one week after the maturity date    </td>
+    The grace period end date as  a timestamp. This is always one week after the maturity date    </td>
       </tr>
 </table>
 

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -227,8 +227,8 @@ Emitted when a token is swept by the contract owner.
 
 ## Errors
 
-### BondNotYetMaturedOrPaid
-* Operation restricted because the Bond has not matured or paid.
+### BondNotYetAfterGracePeriodOrPaid
+* Operation restricted because the Bond has after the grace period or paid.
 
 
 

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -237,6 +237,11 @@ Emitted when a token is swept by the contract owner.
 
 
 
+### CurrentlyGracePeriod
+* Bonds can not be redeemed during the grace period
+
+
+
 ### NoPaymentToWithdraw
 * Attempted to withdraw with no excess payment in the contract.
 

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -237,11 +237,6 @@ Emitted when a token is swept by the contract owner.
 
 
 
-### CurrentlyGracePeriod
-* Bonds can not be redeemed during the grace period
-
-
-
 ### NoPaymentToWithdraw
 * Attempted to withdraw with no excess payment in the contract.
 

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -1,9 +1,13 @@
 # Bond
 
+
 A custom ERC20 token that can be used to issue bonds.The contract handles issuance, payment, conversion, and redemption.
 
 
+
+
 ## Events
+
 
 ### Approval
 
@@ -12,98 +16,156 @@ A custom ERC20 token that can be used to issue bonds.The contract handles issuan
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>owner</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>value</td>
-      </tr>
+    
+  </tr>
+
 </table>
 
+
+
 ### CollateralWithdraw
+
 
 Emitted when collateral is withdrawn.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>receiver</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>token</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
 
+
+
 ### Convert
+
 
 Emitted when bond shares are converted by a Bond holder.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfBondsConverted</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfCollateralTokens</td>
-      </tr>
+    
+  </tr>
+
 </table>
 
+
+
 ### ExcessPaymentWithdraw
+
 
 Emitted when payment over the required amount is withdrawn.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>receiver</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>token</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### OwnershipTransferred
 
@@ -112,94 +174,150 @@ Emitted when payment over the required amount is withdrawn.
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>previousOwner</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>newOwner</td>
-      </tr>
+    
+  </tr>
+
 </table>
 
+
+
 ### Payment
+
 
 Emitted when a portion of the Bond&#39;s principal is paid.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
 
+
+
 ### Redeem
+
 
 Emitted when a bond share is redeemed.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>paymentToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfBondsRedeemed</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfPaymentTokensReceived</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfCollateralTokens</td>
-      </tr>
+    
+  </tr>
+
 </table>
 
+
+
 ### TokenSweep
+
 
 Emitted when a token is swept by the contract owner.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address </td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>receiver</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>contract IERC20Metadata </td>
     <td>token</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### Transfer
 
@@ -208,57 +326,110 @@ Emitted when a token is swept by the contract owner.
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>to</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>value</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 
 ## Errors
 
-### BondNotYetAfterGracePeriodOrPaid
-* Operation restricted because the Bond has after the grace period or paid.
+
+### BondBeforeGracePeriodOrPaid
+
+* Bond redemption is impossible because the grace period has not yet passed or the bond has not been fully paid.
+
+
+
+
 
 
 
 ### BondPastMaturity
+
 * Operation restricted because the Bond has matured.
 
 
 
+
+
+
+
 ### NoPaymentToWithdraw
+
 * Attempted to withdraw with no excess payment in the contract.
 
 
 
+
+
+
+
 ### NotEnoughCollateral
+
 * Attempted to withdraw more collateral than available.
 
 
 
+
+
+
+
 ### PaymentAlreadyMet
+
 * Attempted to pay after payment was met.
 
 
 
+
+
+
+
 ### SweepDisallowedForToken
+
 * Attempted to sweep a token used in the contract.
 
 
 
+
+
+
+
 ### ZeroAmount
+
 * Attempted to perform an action that would do nothing.
+
+
+
+
+
+
 
 
 
@@ -268,265 +439,419 @@ Emitted when a token is swept by the contract owner.
 ## Methods
 
 
+
 ### allowance
+
 
 ```solidity
 function allowance(address owner, address spender) external view returns (uint256)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>owner</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### amountUnpaid
 
+
 ```solidity
 function amountUnpaid() external view returns (uint256 paymentTokens)
+
 ```
 
 The amount of paymentTokens required to fully pay the contract.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of paymentTokens unpaid.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens unpaid.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### approve
 
+
 ```solidity
 function approve(address spender, uint256 amount) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### balanceOf
 
+
 ```solidity
 function balanceOf(address account) external view returns (uint256)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### burn
 
+
 ```solidity
 function burn(uint256 amount) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### burnFrom
 
+
 ```solidity
 function burnFrom(address account, uint256 amount) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### collateralBalance
 
+
 ```solidity
 function collateralBalance() external view returns (uint256 collateralTokens)
+
 ```
 
 The external balance of the ERC20 collateral token.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens in the contract.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens in the contract.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralRatio
 
+
 ```solidity
 function collateralRatio() external view returns (uint256)
+
 ```
 
 The number of collateralTokens per Bond.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens per Bond.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens per Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralToken
 
+
 ```solidity
 function collateralToken() external view returns (address)
+
 ```
 
 The ERC20 token used as collateral backing the bond.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-        <td>
-    The collateralToken&#39;s address.    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The collateralToken&#39;s address.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### convert
 
+
 ```solidity
 function convert(uint256 bonds) external nonpayable
+
 ```
 
 For convertible Bonds (ones with a convertibilityRatio &gt; 0), the Bond holder may convert their bond to underlying collateral at the convertibleRatio. The bond must also have not past maturity for this to be possible.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The number of bonds which will be burnt and converted into the collateral at the convertibleRatio.    </td>
-      </tr>
+    
+    <td>
+    The number of bonds which will be burnt and converted into the collateral at the convertibleRatio.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### convertibleRatio
 
+
 ```solidity
 function convertibleRatio() external view returns (uint256)
+
 ```
 
 The number of convertibleTokens the bonds will convert into.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of convertibleTokens per Bond.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of convertibleTokens per Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### decimals
 
+
 ```solidity
 function decimals() external view returns (uint8)
+
 ```
+
+
+
 
 
 
@@ -535,210 +860,338 @@ function decimals() external view returns (uint8)
 
 
 <table>
+
   <tr>
     <td>
-      uint8    </td>
-      </tr>
+      uint8
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### decreaseAllowance
 
+
 ```solidity
 function decreaseAllowance(address spender, uint256 subtractedValue) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>subtractedValue</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### gracePeriodEnd
 
+
 ```solidity
 function gracePeriodEnd() external view returns (uint256 gracePeriodEndTimestamp)
+
 ```
 
 One week after the maturity date. Bond collateral can be  redeemed after this date.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The grace period end date as  a timestamp. This is always one week after the maturity date    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The grace period end date as  a timestamp. This is always one week after the maturity date
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### increaseAllowance
 
+
 ```solidity
 function increaseAllowance(address spender, uint256 addedValue) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>spender</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>addedValue</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### initialize
 
+
 ```solidity
 function initialize(string bondName, string bondSymbol, address bondOwner, uint256 _maturity, address _paymentToken, address _collateralToken, uint256 _collateralRatio, uint256 _convertibleRatio, uint256 maxSupply) external nonpayable
+
 ```
 
 This one-time setup initiated by the BondFactory initializes the Bond with the given configuration.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>string </td>
     <td>bondName</td>
-        <td>
-    Passed into the ERC20 token to define the name.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>bondSymbol</td>
-        <td>
-    Passed into the ERC20 token to define the symbol.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>bondOwner</td>
-        <td>
-    Ownership of the created Bond is transferred to this address by way of _transferOwnership and also the address that tokens are minted to. See `initialize` in `Bond`.    </td>
-      </tr>
+    
+    <td>
+    Ownership of the created Bond is transferred to this address by way of _transferOwnership and also the address that tokens are minted to. See `initialize` in `Bond`.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_maturity</td>
-        <td>
-    The timestamp at which the Bond will mature.    </td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>_paymentToken</td>
-        <td>
-    The ERC20 token address the Bond is redeemable for.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>_collateralToken</td>
-        <td>
-    The ERC20 token address the Bond is backed by.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_collateralRatio</td>
-        <td>
-    The amount of collateral tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_convertibleRatio</td>
-        <td>
-    The amount of convertible tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maxSupply</td>
-        <td>
-    The amount of Bonds given to the owner during the one- time mint during this initialization.    </td>
-      </tr>
+    
+    <td>
+    The amount of Bonds given to the owner during the one- time mint during this initialization.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### isMature
 
+
 ```solidity
 function isMature() external view returns (bool isBondMature)
+
 ```
 
 Checks if the maturity timestamp has passed.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    Whether or not the Bond has reached maturity.    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    Whether or not the Bond has reached maturity.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### maturity
 
+
 ```solidity
 function maturity() external view returns (uint256)
+
 ```
 
 A date set at Bond creation when the Bond will mature.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The maturity date as a timestamp.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The maturity date as a timestamp.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### name
 
+
 ```solidity
 function name() external view returns (string)
+
 ```
+
+
+
 
 
 
@@ -747,17 +1200,28 @@ function name() external view returns (string)
 
 
 <table>
+
   <tr>
     <td>
-      string    </td>
-      </tr>
+      string
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### owner
 
+
 ```solidity
 function owner() external view returns (address)
+
 ```
+
+
+
 
 
 
@@ -766,240 +1230,390 @@ function owner() external view returns (address)
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-      </tr>
+      address
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### pay
 
+
 ```solidity
 function pay(uint256 amount) external nonpayable
+
 ```
 
 Allows the owner to pay the bond by depositing paymentTokens.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    The number of paymentTokens to deposit.    </td>
-      </tr>
+    
+    <td>
+    The number of paymentTokens to deposit.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### paymentBalance
 
+
 ```solidity
 function paymentBalance() external view returns (uint256 paymentTokens)
+
 ```
 
 Gets the external balance of the ERC20 paymentToken.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of paymentTokens in the contract.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens in the contract.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### paymentToken
 
+
 ```solidity
 function paymentToken() external view returns (address)
+
 ```
 
 This is the token the borrower deposits into the contract and what the Bond holders will receive when redeemed.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-        <td>
-    The address of the token.    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The address of the token.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewConvertBeforeMaturity
 
+
 ```solidity
 function previewConvertBeforeMaturity(uint256 bonds) external view returns (uint256 collateralTokens)
+
 ```
 
 Before maturity, if the given bonds are converted, this would be the number of collateralTokens received. This function rounds down the number of returned collateral.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The number of bond shares burnt and converted into collateralTokens.    </td>
-      </tr>
+    
+    <td>
+    The number of bond shares burnt and converted into collateralTokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens the Bonds would be converted into.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens the Bonds would be converted into.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewRedeemAtMaturity
 
+
 ```solidity
 function previewRedeemAtMaturity(uint256 bonds) external view returns (uint256 paymentTokensToSend, uint256 collateralTokensToSend)
+
 ```
 
 At maturity, if the given bond shares are redeemed, this would be the number of collateralTokens and paymentTokens received by the bond holder. The number of paymentTokens to receive is rounded down.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The number of Bonds to burn and redeem for tokens.    </td>
-      </tr>
+    
+    <td>
+    The number of Bonds to burn and redeem for tokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of paymentTokens that the bond shares would be redeemed for.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens that the bond shares would be redeemed for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens that would be redeemed for.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens that would be redeemed for.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewWithdrawExcessCollateral
 
+
 ```solidity
 function previewWithdrawExcessCollateral() external view returns (uint256 collateralTokens)
+
 ```
 
 The number of collateralTokens that the owner would be able to  withdraw from the contract. This does not take into account an amount of payment like `previewWithdrawExcessCollateralAfterPayment` does. See that function for more information.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens that would be withdrawn.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens that would be withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewWithdrawExcessCollateralAfterPayment
 
+
 ```solidity
 function previewWithdrawExcessCollateralAfterPayment(uint256 payment) external view returns (uint256 collateralTokens)
+
 ```
 
 The number of collateralTokens that the owner would be able to  withdraw from the contract. This function rounds up the number  of collateralTokens required in the contract and therefore may round down the amount received.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>payment</td>
-        <td>
-    The number of paymentTokens to add when previewing a withdraw.    </td>
-      </tr>
+    
+    <td>
+    The number of paymentTokens to add when previewing a withdraw.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens that would be withdrawn.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens that would be withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewWithdrawExcessPayment
 
+
 ```solidity
 function previewWithdrawExcessPayment() external view returns (uint256 paymentTokens)
+
 ```
 
 The number of excess paymentTokens that the owner would be able to withdraw from the contract.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of paymentTokens that would be withdrawn.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens that would be withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### redeem
 
+
 ```solidity
 function redeem(uint256 bonds) external nonpayable
+
 ```
 
 The Bond holder can burn bond shares in return for their portion of paymentTokens and collateralTokens backing the Bonds. These portions of tokens depends on the number of paymentTokens deposited. When the Bond is fully paid, redemption will result in all  paymentTokens. If the Bond has reached maturity without being fully paid, a portion of the collateralTokens will be available.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The number of bond shares to redeem and burn.    </td>
-      </tr>
+    
+    <td>
+    The number of bond shares to redeem and burn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### renounceOwnership
 
+
 ```solidity
 function renounceOwnership() external nonpayable
+
 ```
+
+
+
+
 
 
 
@@ -1007,35 +1621,56 @@ function renounceOwnership() external nonpayable
 
 ### sweep
 
+
 ```solidity
 function sweep(contract IERC20Metadata sweepingToken, address receiver) external nonpayable
+
 ```
 
 Sends ERC20 tokens to the owner that are in this contract.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>contract IERC20Metadata </td>
     <td>sweepingToken</td>
-        <td>
-    The ERC20 token to sweep and send to the receiver.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token to sweep and send to the receiver.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>receiver</td>
-        <td>
-    The address that is transferred the swept token.    </td>
-      </tr>
+    
+    <td>
+    The address that is transferred the swept token.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### symbol
 
+
 ```solidity
 function symbol() external view returns (string)
+
 ```
+
+
+
 
 
 
@@ -1044,17 +1679,28 @@ function symbol() external view returns (string)
 
 
 <table>
+
   <tr>
     <td>
-      string    </td>
-      </tr>
+      string
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### totalSupply
 
+
 ```solidity
 function totalSupply() external view returns (uint256)
+
 ```
+
+
+
 
 
 
@@ -1063,140 +1709,221 @@ function totalSupply() external view returns (uint256)
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-      </tr>
+      uint256
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### transfer
 
+
 ```solidity
 function transfer(address to, uint256 amount) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>to</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### transferFrom
 
+
 ```solidity
 function transferFrom(address from, address to, uint256 amount) external nonpayable returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>from</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>to</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### transferOwnership
 
+
 ```solidity
 function transferOwnership(address newOwner) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>newOwner</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### withdrawExcessCollateral
 
+
 ```solidity
 function withdrawExcessCollateral(uint256 amount, address receiver) external nonpayable
+
 ```
 
 The Owner may withdraw excess collateral from the Bond contract. The number of collateralTokens remaining in the contract must be enough to cover the total supply of Bonds in accordance to both the collateralRatio and convertibleRatio.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    The number of collateralTokens to withdraw. Reverts if the amount is greater than available in the contract.     </td>
-      </tr>
+    
+    <td>
+    The number of collateralTokens to withdraw. Reverts if the amount is greater than available in the contract. 
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>receiver</td>
-        <td>
-    The address transferred the excess collateralTokens.    </td>
-      </tr>
+    
+    <td>
+    The address transferred the excess collateralTokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### withdrawExcessPayment
 
+
 ```solidity
 function withdrawExcessPayment(address receiver) external nonpayable
+
 ```
 
 The owner can withdraw any excess paymentToken in the contract.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>receiver</td>
-        <td>
-    The address that is transferred the excess paymentToken.    </td>
-      </tr>
+    
+    <td>
+    The address that is transferred the excess paymentToken.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -577,6 +577,25 @@ function decreaseAllowance(address spender, uint256 subtractedValue) external no
       </tr>
 </table>
 
+### gracePeriodEnd
+
+```solidity
+function gracePeriodEnd() external view returns (uint256)
+```
+
+
+
+
+#### Returns
+
+
+<table>
+  <tr>
+    <td>
+      uint256    </td>
+      </tr>
+</table>
+
 ### increaseAllowance
 
 ```solidity

--- a/docs/BondFactory.md
+++ b/docs/BondFactory.md
@@ -1,73 +1,113 @@
 # BondFactory
 
+
 This factory contract issues new bond contracts.
+
+
 
 
 ## Events
 
+
 ### BondCreated
+
 
 Emitted when a new bond is created.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address </td>
     <td>newBond</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>name</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>symbol</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>owner</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maturity</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>paymentToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>collateralTokenAmount</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>convertibleTokenAmount</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-      </tr>
+    
+  </tr>
+
 </table>
 
+
+
 ### IssuerAllowListEnabled
+
 
 Emitted when the restriction of bond creation to allow-listed accounts is toggled on or off.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>bool </td>
     <td>isIssuerAllowListEnabled</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### RoleAdminChanged
 
@@ -76,20 +116,33 @@ Emitted when the restriction of bond creation to allow-listed accounts is toggle
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>previousAdminRole</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>newAdminRole</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### RoleGranted
 
@@ -98,20 +151,33 @@ Emitted when the restriction of bond creation to allow-listed accounts is toggle
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>sender</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 ### RoleRevoked
 
@@ -120,66 +186,123 @@ Emitted when the restriction of bond creation to allow-listed accounts is toggle
 
 
 
+
+
+
+
 <table>
+
   <tr>
     <td>bytes32 <code>indexed</code></td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>sender</td>
-      </tr>
+    
+  </tr>
+
 </table>
 
+
+
 ### TokenAllowListEnabled
+
 
 Emitted when the restriction of collateralToken and paymentToken to allow-listed tokens is toggled on or off.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>bool </td>
     <td>isTokenAllowListEnabled</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 
 ## Errors
 
+
 ### CollateralTokenAmountLessThanConvertibleTokenAmount
+
 * There must be more collateralTokens than convertibleTokens.
 
 
 
+
+
+
+
 ### InvalidDeposit
+
 * Fails if the collateralToken takes a fee.
 
 
 
+
+
+
+
 ### InvalidMaturity
+
 * Maturity date is not valid.
 
 
 
+
+
+
+
 ### TokensMustBeDifferent
+
 * The paymentToken and collateralToken must be different.
 
 
 
+
+
+
+
 ### TooManyDecimals
+
 * Decimals with more than 18 digits are not supported.
 
 
 
+
+
+
+
 ### ZeroBondsToMint
+
 * Bonds must be minted during initialization.
+
+
+
+
+
+
 
 
 
@@ -189,415 +312,658 @@ Emitted when the restriction of collateralToken and paymentToken to allow-listed
 ## Methods
 
 
+
 ### ALLOWED_TOKEN
+
 
 ```solidity
 function ALLOWED_TOKEN() external view returns (bytes32)
+
 ```
 
 The role given to allowed tokens.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### DEFAULT_ADMIN_ROLE
 
+
 ```solidity
 function DEFAULT_ADMIN_ROLE() external view returns (bytes32)
+
 ```
 
 
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### ISSUER_ROLE
 
+
 ```solidity
 function ISSUER_ROLE() external view returns (bytes32)
+
 ```
 
 The role required to issue bonds.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### createBond
 
+
 ```solidity
 function createBond(string name, string symbol, uint256 maturity, address paymentToken, address collateralToken, uint256 collateralTokenAmount, uint256 convertibleTokenAmount, uint256 bonds) external nonpayable returns (address clone)
+
 ```
 
 Creates a new Bond. The calculated ratios are rounded down.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>string </td>
     <td>name</td>
-        <td>
-    Passed into the ERC20 token to define the name.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>symbol</td>
-        <td>
-    Passed into the ERC20 token to define the symbol.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maturity</td>
-        <td>
-    The timestamp at which the Bond will mature.    </td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>paymentToken</td>
-        <td>
-    The ERC20 token address the Bond is redeemable for.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>collateralToken</td>
-        <td>
-    The ERC20 token address the Bond is backed by.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>collateralTokenAmount</td>
-        <td>
-    The amount of collateral tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>convertibleTokenAmount</td>
-        <td>
-    The amount of convertible tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The amount of Bonds given to the owner during the one-time mint during the `Bond`&#39;s `initialize`.    </td>
-      </tr>
+    
+    <td>
+    The amount of Bonds given to the owner during the one-time mint during the `Bond`&#39;s `initialize`.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-        <td>
-    The address of the newly created Bond.    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The address of the newly created Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### getRoleAdmin
 
+
 ```solidity
 function getRoleAdmin(bytes32 role) external view returns (bytes32)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bytes32    </td>
-      </tr>
+      bytes32
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### grantRole
 
+
 ```solidity
 function grantRole(bytes32 role, address account) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### hasRole
 
+
 ```solidity
 function hasRole(bytes32 role, address account) external view returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isBond
 
+
 ```solidity
 function isBond(address) external view returns (bool)
+
 ```
 
 Returns whether or not the given address key is a bond created by this Bond factory.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>_0</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isIssuerAllowListEnabled
 
+
 ```solidity
 function isIssuerAllowListEnabled() external view returns (bool)
+
 ```
 
 If enabled, issuance is restricted to those with ISSUER_ROLE.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    isEnabled Whether or not the `ISSUER_ROLE` will be checked when creating new bonds.    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    isEnabled Whether or not the `ISSUER_ROLE` will be checked when creating new bonds.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isTokenAllowListEnabled
 
+
 ```solidity
 function isTokenAllowListEnabled() external view returns (bool)
+
 ```
 
 If enabled, tokens used as paymentToken and collateralToken are restricted to those with the ALLOWED_TOKEN role.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    isEnabled Whether or not the collateralToken and paymentToken are checked for the `ALLOWED_TOKEN` role when creating new bonds.    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    isEnabled Whether or not the collateralToken and paymentToken are checked for the `ALLOWED_TOKEN` role when creating new bonds.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### renounceRole
 
+
 ```solidity
 function renounceRole(bytes32 role, address account) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### revokeRole
 
+
 ```solidity
 function revokeRole(bytes32 role, address account) external nonpayable
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes32 </td>
     <td>role</td>
-      </tr>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>account</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### setIsIssuerAllowListEnabled
 
+
 ```solidity
 function setIsIssuerAllowListEnabled(bool _isIssuerAllowListEnabled) external nonpayable
+
 ```
 
 Sets the state of bond restriction to allow-listed accounts.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>bool </td>
     <td>_isIssuerAllowListEnabled</td>
-        <td>
-    If the issuer allow list should be enabled or not.    </td>
-      </tr>
+    
+    <td>
+    If the issuer allow list should be enabled or not.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### setIsTokenAllowListEnabled
 
+
 ```solidity
 function setIsTokenAllowListEnabled(bool _isTokenAllowListEnabled) external nonpayable
+
 ```
 
 Sets the state of token restriction to the list of allowed tokens.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>bool </td>
     <td>_isTokenAllowListEnabled</td>
-        <td>
-    If the token allow list should be enabled or not.    </td>
-      </tr>
+    
+    <td>
+    If the token allow list should be enabled or not.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### supportsInterface
 
+
 ```solidity
 function supportsInterface(bytes4 interfaceId) external view returns (bool)
+
 ```
+
+
 
 
 
 #### Parameters
 
 <table>
+
   <tr>
     <td>bytes4 </td>
     <td>interfaceId</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### tokenImplementation
 
+
 ```solidity
 function tokenImplementation() external view returns (address)
+
 ```
 
 Address where the bond implementation contract is stored.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-        <td>
-    The implementation address.    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The implementation address.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -387,10 +387,10 @@ The number of convertibleTokens the bonds will convert into.
 ### gracePeriodEnd
 
 ```solidity
-function gracePeriodEnd() external view returns (uint256)
+function gracePeriodEnd() external view returns (uint256 gracePeriodEndTimestamp)
 ```
 
-One week after the maturity date. Bond collateral can be redeemed after this date.
+One week after the maturity date. Bond collateral can be  redeemed after this date.
 
 
 #### Returns
@@ -401,7 +401,7 @@ One week after the maturity date. Bond collateral can be redeemed after this dat
     <td>
       uint256    </td>
         <td>
-    The grace period end date as a timestamp. This is always one week after the maturity date    </td>
+    The grace period end date as  a timestamp. This is always one week after the maturity date    </td>
       </tr>
 </table>
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -223,11 +223,6 @@ Emitted when a token is swept by the contract owner.
 
 
 
-### CurrentlyGracePeriod
-* Bonds can not be redeemed during the grace period
-
-
-
 ### NoPaymentToWithdraw
 * Attempted to withdraw with no excess payment in the contract.
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -213,8 +213,8 @@ Emitted when a token is swept by the contract owner.
 
 ## Errors
 
-### BondNotYetMaturedOrPaid
-* Operation restricted because the Bond has not matured or paid.
+### BondNotYetAfterGracePeriodOrPaid
+* Operation restricted because the Bond has after the grace period or paid.
 
 
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -384,6 +384,27 @@ The number of convertibleTokens the bonds will convert into.
       </tr>
 </table>
 
+### gracePeriodEnd
+
+```solidity
+function gracePeriodEnd() external view returns (uint256)
+```
+
+One week after the maturity date. Bond collateral can be redeemed after this date.
+
+
+#### Returns
+
+
+<table>
+  <tr>
+    <td>
+      uint256    </td>
+        <td>
+    The grace period end date as a timestamp. This is always one week after the maturity date    </td>
+      </tr>
+</table>
+
 ### initialize
 
 ```solidity

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -223,6 +223,11 @@ Emitted when a token is swept by the contract owner.
 
 
 
+### CurrentlyGracePeriod
+* Bonds can not be redeemed during the grace period
+
+
+
 ### NoPaymentToWithdraw
 * Attempted to withdraw with no excess payment in the contract.
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -3,248 +3,430 @@
 
 
 
+
+
+
 ## Events
 
+
 ### CollateralWithdraw
+
 
 Emitted when collateral is withdrawn.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    The address withdrawing the collateralTokens.    </td>
-      </tr>
+    
+    <td>
+    The address withdrawing the collateralTokens.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>receiver</td>
-        <td>
-    The address receiving the collateralTokens.    </td>
-      </tr>
+    
+    <td>
+    The address receiving the collateralTokens.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>token</td>
-        <td>
-    The address of the collateralToken.    </td>
-      </tr>
+    
+    <td>
+    The address of the collateralToken.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    The number of collateralTokens withdrawn.    </td>
-      </tr>
+    
+    <td>
+    The number of collateralTokens withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
 
+
+
 ### Convert
+
 
 Emitted when bond shares are converted by a Bond holder.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    The address converting their tokens.    </td>
-      </tr>
+    
+    <td>
+    The address converting their tokens.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-        <td>
-    The address of the collateralToken.    </td>
-      </tr>
+    
+    <td>
+    The address of the collateralToken.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfBondsConverted</td>
-        <td>
-    The number of burnt bond shares.    </td>
-      </tr>
+    
+    <td>
+    The number of burnt bond shares.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfCollateralTokens</td>
-        <td>
-    The number of collateralTokens received.    </td>
-      </tr>
+    
+    <td>
+    The number of collateralTokens received.
+    </td>
+    
+  </tr>
+
 </table>
 
+
+
 ### ExcessPaymentWithdraw
+
 
 Emitted when payment over the required amount is withdrawn.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    The caller withdrawing the excess payment amount.    </td>
-      </tr>
+    
+    <td>
+    The caller withdrawing the excess payment amount.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>receiver</td>
-        <td>
-    The address receiving the paymentTokens.    </td>
-      </tr>
+    
+    <td>
+    The address receiving the paymentTokens.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>token</td>
-        <td>
-    The address of the paymentToken being withdrawn.    </td>
-      </tr>
+    
+    <td>
+    The address of the paymentToken being withdrawn.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    The amount of paymentToken withdrawn.    </td>
-      </tr>
+    
+    <td>
+    The amount of paymentToken withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### Payment
 
+
 Emitted when a portion of the Bond&#39;s principal is paid.
+
 
 *The amount could be incorrect if the token takes a fee on transfer. *
 
 
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    The address depositing payment.    </td>
-      </tr>
+    
+    <td>
+    The address depositing payment.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    Amount paid.    </td>
-      </tr>
+    
+    <td>
+    Amount paid.
+    </td>
+    
+  </tr>
+
 </table>
 
+
+
 ### Redeem
+
 
 Emitted when a bond share is redeemed.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>from</td>
-        <td>
-    The Bond holder whose bond shares are burnt.    </td>
-      </tr>
+    
+    <td>
+    The Bond holder whose bond shares are burnt.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>paymentToken</td>
-        <td>
-    The address of the paymentToken.    </td>
-      </tr>
+    
+    <td>
+    The address of the paymentToken.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-        <td>
-    The address of the collateralToken.    </td>
-      </tr>
+    
+    <td>
+    The address of the collateralToken.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfBondsRedeemed</td>
-        <td>
-    The number of bond shares burned for redemption.    </td>
-      </tr>
+    
+    <td>
+    The number of bond shares burned for redemption.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfPaymentTokensReceived</td>
-        <td>
-    The number of paymentTokens.    </td>
-      </tr>
+    
+    <td>
+    The number of paymentTokens.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amountOfCollateralTokens</td>
-        <td>
-    The number of collateralTokens.    </td>
-      </tr>
+    
+    <td>
+    The number of collateralTokens.
+    </td>
+    
+  </tr>
+
 </table>
 
+
+
 ### TokenSweep
+
 
 Emitted when a token is swept by the contract owner.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address </td>
     <td>from</td>
-        <td>
-    The owner&#39;s address.    </td>
-      </tr>
+    
+    <td>
+    The owner&#39;s address.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>receiver</td>
-        <td>
-    The address receiving the swept tokens.    </td>
-      </tr>
+    
+    <td>
+    The address receiving the swept tokens.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>contract IERC20Metadata </td>
     <td>token</td>
-        <td>
-    The address of the token that was swept.    </td>
-      </tr>
+    
+    <td>
+    The address of the token that was swept.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    The number of tokens swept.    </td>
-      </tr>
+    
+    <td>
+    The number of tokens swept.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 
 ## Errors
 
-### BondNotYetAfterGracePeriodOrPaid
-* Operation restricted because the Bond has after the grace period or paid.
+
+### BondBeforeGracePeriodOrPaid
+
+* Bond redemption is impossible because the grace period has not yet passed or the bond has not been fully paid.
+
+
+
+
 
 
 
 ### BondPastMaturity
+
 * Operation restricted because the Bond has matured.
 
 
 
+
+
+
+
 ### NoPaymentToWithdraw
+
 * Attempted to withdraw with no excess payment in the contract.
 
 
 
+
+
+
+
 ### NotEnoughCollateral
+
 * Attempted to withdraw more collateral than available.
 
 
 
+
+
+
+
 ### PaymentAlreadyMet
+
 * Attempted to pay after payment was met.
 
 
 
+
+
+
+
 ### SweepDisallowedForToken
+
 * Attempted to sweep a token used in the contract.
 
 
 
+
+
+
+
 ### ZeroAmount
+
 * Attempted to perform an action that would do nothing.
+
+
+
+
+
+
 
 
 
@@ -254,555 +436,899 @@ Emitted when a token is swept by the contract owner.
 ## Methods
 
 
+
 ### amountUnpaid
+
 
 ```solidity
 function amountUnpaid() external view returns (uint256 paymentTokens)
+
 ```
 
 The amount of paymentTokens required to fully pay the contract.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of paymentTokens unpaid.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens unpaid.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralBalance
 
+
 ```solidity
 function collateralBalance() external view returns (uint256 collateralTokens)
+
 ```
 
 The external balance of the ERC20 collateral token.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens in the contract.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens in the contract.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralRatio
 
+
 ```solidity
 function collateralRatio() external view returns (uint256)
+
 ```
 
 The number of collateralTokens per Bond.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens per Bond.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens per Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### collateralToken
 
+
 ```solidity
 function collateralToken() external view returns (address)
+
 ```
 
 The ERC20 token used as collateral backing the bond.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-        <td>
-    The collateralToken&#39;s address.    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The collateralToken&#39;s address.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### convert
 
+
 ```solidity
 function convert(uint256 bonds) external nonpayable
+
 ```
 
 For convertible Bonds (ones with a convertibilityRatio &gt; 0), the Bond holder may convert their bond to underlying collateral at the convertibleRatio. The bond must also have not past maturity for this to be possible.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The number of bonds which will be burnt and converted into the collateral at the convertibleRatio.    </td>
-      </tr>
+    
+    <td>
+    The number of bonds which will be burnt and converted into the collateral at the convertibleRatio.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### convertibleRatio
 
+
 ```solidity
 function convertibleRatio() external view returns (uint256)
+
 ```
 
 The number of convertibleTokens the bonds will convert into.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of convertibleTokens per Bond.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of convertibleTokens per Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### gracePeriodEnd
 
+
 ```solidity
 function gracePeriodEnd() external view returns (uint256 gracePeriodEndTimestamp)
+
 ```
 
 One week after the maturity date. Bond collateral can be  redeemed after this date.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The grace period end date as  a timestamp. This is always one week after the maturity date    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The grace period end date as  a timestamp. This is always one week after the maturity date
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### initialize
 
+
 ```solidity
 function initialize(string bondName, string bondSymbol, address bondOwner, uint256 _maturity, address _paymentToken, address _collateralToken, uint256 _collateralRatio, uint256 _convertibleRatio, uint256 maxSupply) external nonpayable
+
 ```
 
 This one-time setup initiated by the BondFactory initializes the Bond with the given configuration.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>string </td>
     <td>bondName</td>
-        <td>
-    Passed into the ERC20 token to define the name.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>bondSymbol</td>
-        <td>
-    Passed into the ERC20 token to define the symbol.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>bondOwner</td>
-        <td>
-    Ownership of the created Bond is transferred to this address by way of _transferOwnership and also the address that tokens are minted to. See `initialize` in `Bond`.    </td>
-      </tr>
+    
+    <td>
+    Ownership of the created Bond is transferred to this address by way of _transferOwnership and also the address that tokens are minted to. See `initialize` in `Bond`.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_maturity</td>
-        <td>
-    The timestamp at which the Bond will mature.    </td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>_paymentToken</td>
-        <td>
-    The ERC20 token address the Bond is redeemable for.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>_collateralToken</td>
-        <td>
-    The ERC20 token address the Bond is backed by.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_collateralRatio</td>
-        <td>
-    The amount of collateral tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>_convertibleRatio</td>
-        <td>
-    The amount of convertible tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maxSupply</td>
-        <td>
-    The amount of Bonds given to the owner during the one- time mint during this initialization.    </td>
-      </tr>
+    
+    <td>
+    The amount of Bonds given to the owner during the one- time mint during this initialization.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### isMature
 
+
 ```solidity
 function isMature() external view returns (bool isBondMature)
+
 ```
 
 Checks if the maturity timestamp has passed.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    Whether or not the Bond has reached maturity.    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    Whether or not the Bond has reached maturity.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### maturity
 
+
 ```solidity
 function maturity() external view returns (uint256)
+
 ```
 
 A date set at Bond creation when the Bond will mature.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The maturity date as a timestamp.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The maturity date as a timestamp.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### pay
 
+
 ```solidity
 function pay(uint256 amount) external nonpayable
+
 ```
 
 Allows the owner to pay the bond by depositing paymentTokens.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    The number of paymentTokens to deposit.    </td>
-      </tr>
+    
+    <td>
+    The number of paymentTokens to deposit.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### paymentBalance
 
+
 ```solidity
 function paymentBalance() external view returns (uint256 paymentTokens)
+
 ```
 
 Gets the external balance of the ERC20 paymentToken.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of paymentTokens in the contract.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens in the contract.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### paymentToken
 
+
 ```solidity
 function paymentToken() external view returns (address)
+
 ```
 
 This is the token the borrower deposits into the contract and what the Bond holders will receive when redeemed.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-        <td>
-    The address of the token.    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The address of the token.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewConvertBeforeMaturity
 
+
 ```solidity
 function previewConvertBeforeMaturity(uint256 bonds) external view returns (uint256 collateralTokens)
+
 ```
 
 Before maturity, if the given bonds are converted, this would be the number of collateralTokens received. This function rounds down the number of returned collateral.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The number of bond shares burnt and converted into collateralTokens.    </td>
-      </tr>
+    
+    <td>
+    The number of bond shares burnt and converted into collateralTokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens the Bonds would be converted into.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens the Bonds would be converted into.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewRedeemAtMaturity
 
+
 ```solidity
 function previewRedeemAtMaturity(uint256 bonds) external view returns (uint256 paymentTokensToSend, uint256 collateralTokensToSend)
+
 ```
 
 At maturity, if the given bond shares are redeemed, this would be the number of collateralTokens and paymentTokens received by the bond holder. The number of paymentTokens to receive is rounded down.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The number of Bonds to burn and redeem for tokens.    </td>
-      </tr>
+    
+    <td>
+    The number of Bonds to burn and redeem for tokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of paymentTokens that the bond shares would be redeemed for.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens that the bond shares would be redeemed for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens that would be redeemed for.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens that would be redeemed for.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewWithdrawExcessCollateral
 
+
 ```solidity
 function previewWithdrawExcessCollateral() external view returns (uint256 collateralTokens)
+
 ```
 
 The number of collateralTokens that the owner would be able to  withdraw from the contract. This does not take into account an amount of payment like `previewWithdrawExcessCollateralAfterPayment` does. See that function for more information.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens that would be withdrawn.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens that would be withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewWithdrawExcessCollateralAfterPayment
 
+
 ```solidity
 function previewWithdrawExcessCollateralAfterPayment(uint256 payment) external view returns (uint256 collateralTokens)
+
 ```
 
 The number of collateralTokens that the owner would be able to  withdraw from the contract. This function rounds up the number  of collateralTokens required in the contract and therefore may round down the amount received.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>payment</td>
-        <td>
-    The number of paymentTokens to add when previewing a withdraw.    </td>
-      </tr>
+    
+    <td>
+    The number of paymentTokens to add when previewing a withdraw.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of collateralTokens that would be withdrawn.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of collateralTokens that would be withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### previewWithdrawExcessPayment
 
+
 ```solidity
 function previewWithdrawExcessPayment() external view returns (uint256 paymentTokens)
+
 ```
 
 The number of excess paymentTokens that the owner would be able to withdraw from the contract.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      uint256    </td>
-        <td>
-    The number of paymentTokens that would be withdrawn.    </td>
-      </tr>
+      uint256
+    </td>
+    
+    <td>
+    The number of paymentTokens that would be withdrawn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### redeem
 
+
 ```solidity
 function redeem(uint256 bonds) external nonpayable
+
 ```
 
 The Bond holder can burn bond shares in return for their portion of paymentTokens and collateralTokens backing the Bonds. These portions of tokens depends on the number of paymentTokens deposited. When the Bond is fully paid, redemption will result in all  paymentTokens. If the Bond has reached maturity without being fully paid, a portion of the collateralTokens will be available.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The number of bond shares to redeem and burn.    </td>
-      </tr>
+    
+    <td>
+    The number of bond shares to redeem and burn.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### sweep
 
+
 ```solidity
 function sweep(contract IERC20Metadata sweepingToken, address receiver) external nonpayable
+
 ```
 
 Sends ERC20 tokens to the owner that are in this contract.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>contract IERC20Metadata </td>
     <td>sweepingToken</td>
-        <td>
-    The ERC20 token to sweep and send to the receiver.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token to sweep and send to the receiver.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>receiver</td>
-        <td>
-    The address that is transferred the swept token.    </td>
-      </tr>
+    
+    <td>
+    The address that is transferred the swept token.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### withdrawExcessCollateral
 
+
 ```solidity
 function withdrawExcessCollateral(uint256 amount, address receiver) external nonpayable
+
 ```
 
 The Owner may withdraw excess collateral from the Bond contract. The number of collateralTokens remaining in the contract must be enough to cover the total supply of Bonds in accordance to both the collateralRatio and convertibleRatio.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>uint256 </td>
     <td>amount</td>
-        <td>
-    The number of collateralTokens to withdraw. Reverts if the amount is greater than available in the contract.     </td>
-      </tr>
+    
+    <td>
+    The number of collateralTokens to withdraw. Reverts if the amount is greater than available in the contract. 
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>receiver</td>
-        <td>
-    The address transferred the excess collateralTokens.    </td>
-      </tr>
+    
+    <td>
+    The address transferred the excess collateralTokens.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### withdrawExcessPayment
 
+
 ```solidity
 function withdrawExcessPayment(address receiver) external nonpayable
+
 ```
 
 The owner can withdraw any excess paymentToken in the contract.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>receiver</td>
-        <td>
-    The address that is transferred the excess paymentToken.    </td>
-      </tr>
+    
+    <td>
+    The address that is transferred the excess paymentToken.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 

--- a/docs/interfaces/IBondFactory.md
+++ b/docs/interfaces/IBondFactory.md
@@ -3,141 +3,249 @@
 
 
 
+
+
+
 ## Events
 
+
 ### BondCreated
+
 
 Emitted when a new bond is created.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>address </td>
     <td>newBond</td>
-        <td>
-    The address of the newly deployed bond.    </td>
-      </tr>
+    
+    <td>
+    The address of the newly deployed bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>name</td>
-        <td>
-    Passed into the ERC20 token to define the name.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>symbol</td>
-        <td>
-    Passed into the ERC20 token to define the symbol.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>owner</td>
-        <td>
-    Ownership of the created Bond is transferred to this address by way of _transferOwnership and tokens are minted to this address. See `initialize` in `Bond`.    </td>
-      </tr>
+    
+    <td>
+    Ownership of the created Bond is transferred to this address by way of _transferOwnership and tokens are minted to this address. See `initialize` in `Bond`.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maturity</td>
-        <td>
-    The timestamp at which the Bond will mature.    </td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>paymentToken</td>
-        <td>
-    The ERC20 token address the Bond is redeemable for.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address <code>indexed</code></td>
     <td>collateralToken</td>
-        <td>
-    The ERC20 token address the Bond is backed by.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>collateralTokenAmount</td>
-        <td>
-    The amount of collateral tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>convertibleTokenAmount</td>
-        <td>
-    The amount of convertible tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The amount of bond shares to give to the owner during the one-time mint during the `Bond`&#39;s `initialize`.    </td>
-      </tr>
+    
+    <td>
+    The amount of bond shares to give to the owner during the one-time mint during the `Bond`&#39;s `initialize`.
+    </td>
+    
+  </tr>
+
 </table>
 
+
+
 ### IssuerAllowListEnabled
+
 
 Emitted when the restriction of bond creation to allow-listed accounts is toggled on or off.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>bool </td>
     <td>isIssuerAllowListEnabled</td>
-        <td>
-    The new state of the allow list.    </td>
-      </tr>
+    
+    <td>
+    The new state of the allow list.
+    </td>
+    
+  </tr>
+
 </table>
 
+
+
 ### TokenAllowListEnabled
+
 
 Emitted when the restriction of collateralToken and paymentToken to allow-listed tokens is toggled on or off.
 
 
 
 
+
+
+
 <table>
+
   <tr>
     <td>bool </td>
     <td>isTokenAllowListEnabled</td>
-        <td>
-    The new state of the allow list.    </td>
-      </tr>
+    
+    <td>
+    The new state of the allow list.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
+
 
 
 
 ## Errors
 
+
 ### CollateralTokenAmountLessThanConvertibleTokenAmount
+
 * There must be more collateralTokens than convertibleTokens.
 
 
 
+
+
+
+
 ### InvalidDeposit
+
 * Fails if the collateralToken takes a fee.
 
 
 
+
+
+
+
 ### InvalidMaturity
+
 * Maturity date is not valid.
 
 
 
+
+
+
+
 ### TokensMustBeDifferent
+
 * The paymentToken and collateralToken must be different.
 
 
 
+
+
+
+
 ### TooManyDecimals
+
 * Decimals with more than 18 digits are not supported.
 
 
 
+
+
+
+
 ### ZeroBondsToMint
+
 * Bonds must be minted during initialization.
+
+
+
+
+
+
 
 
 
@@ -147,207 +255,334 @@ Emitted when the restriction of collateralToken and paymentToken to allow-listed
 ## Methods
 
 
+
 ### createBond
+
 
 ```solidity
 function createBond(string name, string symbol, uint256 maturity, address paymentToken, address collateralToken, uint256 collateralTokenAmount, uint256 convertibleTokenAmount, uint256 bonds) external nonpayable returns (address clone)
+
 ```
 
 Creates a new Bond. The calculated ratios are rounded down.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>string </td>
     <td>name</td>
-        <td>
-    Passed into the ERC20 token to define the name.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the name.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>string </td>
     <td>symbol</td>
-        <td>
-    Passed into the ERC20 token to define the symbol.    </td>
-      </tr>
+    
+    <td>
+    Passed into the ERC20 token to define the symbol.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>maturity</td>
-        <td>
-    The timestamp at which the Bond will mature.    </td>
-      </tr>
+    
+    <td>
+    The timestamp at which the Bond will mature.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>paymentToken</td>
-        <td>
-    The ERC20 token address the Bond is redeemable for.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is redeemable for.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>address </td>
     <td>collateralToken</td>
-        <td>
-    The ERC20 token address the Bond is backed by.    </td>
-      </tr>
+    
+    <td>
+    The ERC20 token address the Bond is backed by.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>collateralTokenAmount</td>
-        <td>
-    The amount of collateral tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of collateral tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>convertibleTokenAmount</td>
-        <td>
-    The amount of convertible tokens per bond.    </td>
-      </tr>
+    
+    <td>
+    The amount of convertible tokens per bond.
+    </td>
+    
+  </tr>
+
   <tr>
     <td>uint256 </td>
     <td>bonds</td>
-        <td>
-    The amount of Bonds given to the owner during the one-time mint during the `Bond`&#39;s `initialize`.    </td>
-      </tr>
+    
+    <td>
+    The amount of Bonds given to the owner during the one-time mint during the `Bond`&#39;s `initialize`.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-        <td>
-    The address of the newly created Bond.    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The address of the newly created Bond.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isBond
 
+
 ```solidity
 function isBond(address) external view returns (bool)
+
 ```
 
 Returns whether or not the given address key is a bond created by this Bond factory.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>address </td>
     <td>_0</td>
-      </tr>
+    
+  </tr>
+
 </table>
+
+
 
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-      </tr>
+      bool
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isIssuerAllowListEnabled
 
+
 ```solidity
 function isIssuerAllowListEnabled() external view returns (bool isEnabled)
+
 ```
 
 If enabled, issuance is restricted to those with ISSUER_ROLE.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    Whether or not the `ISSUER_ROLE` will be checked when creating new bonds.    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    Whether or not the `ISSUER_ROLE` will be checked when creating new bonds.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### isTokenAllowListEnabled
 
+
 ```solidity
 function isTokenAllowListEnabled() external view returns (bool isEnabled)
+
 ```
 
 If enabled, tokens used as paymentToken and collateralToken are restricted to those with the ALLOWED_TOKEN role.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      bool    </td>
-        <td>
-    Whether or not the collateralToken and paymentToken are checked for the `ALLOWED_TOKEN` role when creating new bonds.    </td>
-      </tr>
+      bool
+    </td>
+    
+    <td>
+    Whether or not the collateralToken and paymentToken are checked for the `ALLOWED_TOKEN` role when creating new bonds.
+    </td>
+    
+  </tr>
+
 </table>
+
+
 
 ### setIsIssuerAllowListEnabled
 
+
 ```solidity
 function setIsIssuerAllowListEnabled(bool _isIssuerAllowListEnabled) external nonpayable
+
 ```
 
 Sets the state of bond restriction to allow-listed accounts.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>bool </td>
     <td>_isIssuerAllowListEnabled</td>
-        <td>
-    If the issuer allow list should be enabled or not.    </td>
-      </tr>
+    
+    <td>
+    If the issuer allow list should be enabled or not.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### setIsTokenAllowListEnabled
 
+
 ```solidity
 function setIsTokenAllowListEnabled(bool _isTokenAllowListEnabled) external nonpayable
+
 ```
 
 Sets the state of token restriction to the list of allowed tokens.
 
+
+
 #### Parameters
 
 <table>
+
   <tr>
     <td>bool </td>
     <td>_isTokenAllowListEnabled</td>
-        <td>
-    If the token allow list should be enabled or not.    </td>
-      </tr>
+    
+    <td>
+    If the token allow list should be enabled or not.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 
 ### tokenImplementation
 
+
 ```solidity
 function tokenImplementation() external view returns (address)
+
 ```
 
 Address where the bond implementation contract is stored.
 
 
+
+
+
 #### Returns
 
 
 <table>
+
   <tr>
     <td>
-      address    </td>
-        <td>
-    The implementation address.    </td>
-      </tr>
+      address
+    </td>
+    
+    <td>
+    The implementation address.
+    </td>
+    
+  </tr>
+
 </table>
+
+
+
 
 

--- a/spec/stateMachine.md
+++ b/spec/stateMachine.md
@@ -8,12 +8,12 @@
 
 ## Not fully paid and not matured (Active)
 
-- When maturity date passes move to "Not fully paid and matured"
+- When maturity date plus the grace period passes, move to "Not fully paid and matured"
 - Anyone can fully pay and move to "Fully paid and not matured"
 
 ## Fully paid and not matured (PaidEarly)
 
-- When maturity date passes move to "Fully paid and matured"
+- When maturity date passes, move to "Fully paid and matured"
 
 ## Not fully paid and matured (Defaulted)
 

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -741,7 +741,10 @@ describe("Bond", () => {
         });
         describe("Defaulted state", async () => {
           beforeEach(async () => {
-            await ethers.provider.send("evm_mine", [config.maturity]);
+            const gracePeriodEnd = await (
+              await bond.gracePeriodEnd()
+            ).toNumber();
+            await ethers.provider.send("evm_mine", [gracePeriodEnd]);
           });
 
           it("should not be possible to redeem zero bonds", async () => {
@@ -867,7 +870,7 @@ describe("Bond", () => {
             });
 
             await expect(bond.redeem(ZERO)).to.be.revertedWith(
-              "BondNotYetMaturedOrPaid"
+              "BondNotYetAfterGracePeriodOrPaid"
             );
           });
 

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -740,22 +740,24 @@ describe("Bond", () => {
           });
         });
 
-        describe("Defaulted state (Before Grace Period)", async () => {
+        describe("Defaulted state (during grace period)", async () => {
           beforeEach(async () => {
+            // Skip to maturity as this is the start of the grace period
             await ethers.provider.send("evm_mine", [config.maturity]);
           });
 
-          it("fails when trying to redeem during grace period", async () => {
+          it("fails when trying to redeem", async () => {
             await expect(bond.redeem(1)).to.be.revertedWith(
-              "BondNotYetAfterGracePeriodOrPaid"
+              "BondBeforeGracePeriodOrPaid"
             );
           });
         });
-        describe("Defaulted state (After Grace Period)", async () => {
+        describe("Defaulted state (after grace period)", async () => {
           beforeEach(async () => {
             const gracePeriodEnd = await (
               await bond.gracePeriodEnd()
             ).toNumber();
+            // The grace period is considered over at the timestamp and onward
             await ethers.provider.send("evm_mine", [gracePeriodEnd]);
           });
 
@@ -882,7 +884,7 @@ describe("Bond", () => {
             });
 
             await expect(bond.redeem(ZERO)).to.be.revertedWith(
-              "BondNotYetAfterGracePeriodOrPaid"
+              "BondBeforeGracePeriodOrPaid"
             );
           });
 

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -739,7 +739,19 @@ describe("Bond", () => {
             await expect(bond.redeem(ZERO)).to.be.revertedWith("ZeroAmount");
           });
         });
-        describe("Defaulted state", async () => {
+
+        describe("Defaulted state (Before Grace Period)", async () => {
+          beforeEach(async () => {
+            await ethers.provider.send("evm_mine", [config.maturity]);
+          });
+
+          it("fails when trying to redeem during grace period", async () => {
+            await expect(bond.redeem(1)).to.be.revertedWith(
+              "BondNotYetAfterGracePeriodOrPaid"
+            );
+          });
+        });
+        describe("Defaulted state (After Grace Period)", async () => {
           beforeEach(async () => {
             const gracePeriodEnd = await (
               await bond.gracePeriodEnd()


### PR DESCRIPTION
This adds a one week period after default where bonds can not be redeemed. 

After 1 week past maturity, bonds can be redeemed like normal. 

This helps protect against a DAO slightly missing their repayment window. 