### PR TITLE
Disallow Burn from Non-Owner

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -414,6 +414,11 @@ contract Bond is
         return IERC20Metadata(paymentToken).decimals();
     }
 
+    /// @inheritdoc ERC20BurnableUpgradeable
+    function burn(uint256 amount) public override onlyOwner {
+        return super.burn(amount);
+    }
+
     /**
         @notice Checks if the grace period timestamp has passed.
         @return isGracePeriodOver Whether or not the Bond is past the

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -1046,6 +1046,20 @@ describe("Bond", () => {
           });
         });
       });
+      describe("burn", async () => {
+        describe("non convertible", async () => {
+          beforeEach(async () => {
+            bond = bondWithTokens.nonConvertible.bond;
+            config = bondWithTokens.nonConvertible.config;
+          });
+
+          it("fails when a non-owner tries to burn bonds", async () => {
+            await expect(
+              bond.connect(bondHolder).burn(config.maxSupply)
+            ).to.be.revertedWith("Ownable: caller is not the owner");
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
closes #273 

This adds the `onlyOwner` modifier to the burn method. This prevents non-owners from accidentally burning bonds.