### PR TITLE
Add Check for too-large Bond Supply

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -94,6 +94,13 @@ contract Bond is
         uint256 _convertibleRatio,
         uint256 maxSupply
     ) external initializer {
+        /*
+            Safety check: Ensure multiplication can not overflow uint256.
+        */
+        maxSupply * maxSupply;
+        maxSupply * _collateralRatio;
+        maxSupply * _convertibleRatio;
+
         __ERC20_init(bondName, bondSymbol);
         _transferOwnership(bondOwner);
 

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -94,9 +94,7 @@ contract Bond is
         uint256 _convertibleRatio,
         uint256 maxSupply
     ) external initializer {
-        /*
-            Safety check: Ensure multiplication can not overflow uint256.
-        */
+        // Safety checks: Ensure multiplication can not overflow uint256.
         maxSupply * maxSupply;
         maxSupply * _collateralRatio;
         maxSupply * _convertibleRatio;

--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -103,6 +103,13 @@ contract BondFactory is IBondFactory, AccessControl {
         if (bonds == 0) {
             revert ZeroBondsToMint();
         }
+
+        /*
+            Safety check: Ensure multiplicative result of total bonds does not
+            overflow uint256. If it does, previewRedeem would not be calculable.
+        */
+        bonds * bonds;
+
         if (paymentToken == collateralToken) {
             revert TokensMustBeDifferent();
         }

--- a/contracts/BondFactory.sol
+++ b/contracts/BondFactory.sol
@@ -103,13 +103,6 @@ contract BondFactory is IBondFactory, AccessControl {
         if (bonds == 0) {
             revert ZeroBondsToMint();
         }
-
-        /*
-            Safety check: Ensure multiplicative result of total bonds does not
-            overflow uint256. If it does, previewRedeem would not be calculable.
-        */
-        bonds * bonds;
-
         if (paymentToken == collateralToken) {
             revert TokensMustBeDifferent();
         }

--- a/test/BondFactory.spec.ts
+++ b/test/BondFactory.spec.ts
@@ -9,6 +9,7 @@ import {
   THREE_YEARS_FROM_NOW_IN_SECONDS,
   ELEVEN_YEARS_FROM_NOW_IN_SECONDS,
   ZERO,
+  SQRT_MAX_UINT256,
 } from "./constants";
 
 const { ethers } = require("hardhat");
@@ -101,6 +102,20 @@ describe("BondFactory", async () => {
           maxSupply: ZERO,
         })
       ).to.be.revertedWith("ZeroBondsToMint");
+    });
+
+    it("fails if bonds would overflow", async () => {
+      await factory.grantRole(ISSUER_ROLE, owner.address);
+      await expect(
+        createBond(factory, {
+          maxSupply: SQRT_MAX_UINT256.sub(1),
+        })
+      ).to.not.be.reverted;
+      await expect(
+        createBond(factory, {
+          maxSupply: SQRT_MAX_UINT256,
+        })
+      ).to.be.revertedWith("overflow");
     });
 
     it("fails if collateralToken == paymentToken", async () => {

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -29,7 +29,9 @@ export const ELEVEN_YEARS_FROM_NOW_IN_SECONDS = Math.round(
 
 export const ONE = utils.parseUnits("1", 18);
 export const WAD = utils.parseUnits("1", 18);
-
+export const SQRT_MAX_UINT256 = BigNumber.from(
+  "340282366920938463463374607431768211456"
+);
 export const ZERO = BigNumber.from(0);
 export const FIFTY_MILLION = 50000000;
 export const TWENTY_FIVE_MILLION = (25000000).toString();


### PR DESCRIPTION
https://github.com/spearbit-audits/porter/issues/17

Description:

Issuing too many bonds can result in users being unable to redeem. This is caused by arithmetic overflow in previewRedeemAtMaturity.

If a user's bonds and the paidAmount's (or bonds * nonPaidAmount) product is greater than 2**256, it will overflow, reverting all attempts to redeem bonds.


This is fixed by adding the safety checks