### PR TITLE
Revert "Disallow Burn from Non-Owner"

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -444,11 +444,6 @@ contract Bond is
         return IERC20Metadata(paymentToken).decimals();
     }
 
-    /// @inheritdoc ERC20BurnableUpgradeable
-    function burn(uint256 amount) public override onlyOwner {
-        return super.burn(amount);
-    }
-
     /**
         @notice Checks if the grace period timestamp has passed.
         @return isGracePeriodOver Whether or not the Bond is past the

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -1105,20 +1105,6 @@ describe("Bond", () => {
           });
         });
       });
-      describe("burn", async () => {
-        describe("non convertible", async () => {
-          beforeEach(async () => {
-            bond = bondWithTokens.nonConvertible.bond;
-            config = bondWithTokens.nonConvertible.config;
-          });
-
-          it("fails when a non-owner tries to burn bonds", async () => {
-            await expect(
-              bond.connect(bondHolder).burn(config.maxSupply)
-            ).to.be.revertedWith("Ownable: caller is not the owner");
-          });
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
Reverts porter-finance/v1-core#288 due to introducing a bug where lenders could no longer `convert` or `redeem` bonds 