### PR TITLE
Use Internal Burn

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -129,7 +129,7 @@ contract Bond is
             revert ZeroAmount();
         }
 
-        burn(bonds);
+        _burn(_msgSender(), bonds);
 
         address _collateralToken = collateralToken;
 
@@ -198,7 +198,7 @@ contract Bond is
             revert ZeroAmount();
         }
 
-        burn(bonds);
+        _burn(_msgSender(), bonds);
 
         address _paymentToken = paymentToken;
         address _collateralToken = collateralToken;


### PR DESCRIPTION
Previously, the `redeem` and `convert` methods were using the `public` burn from `ERC20BurnableUpgradeable` which called `ERC20Upgradeable`'s `_burn`. This changes the call to use the internal burn explicitly. 