### PR TITLE
fix failure without .env

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,7 +38,7 @@ const config: HardhatUserConfig = {
         auto: false,
         interval: 10,
       },
-      url: process.env.RINKEBY_RPC_URL,
+      url: process.env.RINKEBY_RPC_URL || "",
       gasMultiplier: 2,
       gasPrice: 4_000_000_000,
       accounts:
@@ -47,7 +47,7 @@ const config: HardhatUserConfig = {
     mumbai: {
       live: true,
       gasPrice: 35000000000,
-      url: process.env.POLYGON_RPC_URL,
+      url: process.env.POLYGON_RPC_URL || "",
       gasMultiplier: 2,
       accounts:
         process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
@@ -57,10 +57,10 @@ const config: HardhatUserConfig = {
         auto: true,
         interval: 10,
       },
-      forking: {
-        blockNumber: 10453255,
-        url: process.env.RINKEBY_RPC_URL || "",
-      },
+      // forking: {
+      //   blockNumber: 10453255,
+      //   url: process.env.RINKEBY_RPC_URL || "",
+      // },
     },
   },
   gasReporter: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "hardhat-project",
+      "hasInstallScript": true,
       "dependencies": {
         "@primitivefi/hardhat-dodoc": "^0.2.3"
       },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hardhat-project",
   "scripts": {
     "prepare": "husky install",
+    "postinstall": "npx hardhat typechain",
     "echidna": "export TERMINFO=/usr/share/terminfo && hardhat compile && echidna-test . --contract TestBond --config ./echidna.config.yaml"
   },
   "devDependencies": {

--- a/tasks/settleAuction.ts
+++ b/tasks/settleAuction.ts
@@ -1,6 +1,5 @@
 import { task } from "hardhat/config";
 import { easyAuctionAbi, rinkebyGnosis } from "../test/constants";
-import { Bond } from "../typechain";
 
 task("settle-auction", "Settles auction if it can be settled.")
   .addParam("auctionId", "The ID of the auction to settle.")
@@ -13,10 +12,7 @@ task("settle-auction", "Settles auction if it can be settled.")
       console.log(auctionEndDate);
       await (await auction.settleAuction(auctionId)).wait();
 
-      const bond = (await ethers.getContractAt(
-        "Bond",
-        auctioningToken
-      )) as Bond;
+      const bond = await ethers.getContractAt("Bond", auctioningToken);
 
       console.log(`
 Settling auction for ${await bond.symbol()}.

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -1,4 +1,4 @@
-import { BigNumber, utils, BytesLike } from "ethers";
+import { BigNumber, utils } from "ethers";
 import { expect } from "chai";
 import { TestERC20, Bond, BondFactory } from "../typechain";
 import {


### PR DESCRIPTION
This issue was introduced with https://github.com/porter-finance/v1-core/pull/281

Previous error: 
<img width="726" alt="image" src="https://user-images.githubusercontent.com/15036618/168169960-ee7102d0-f274-4462-a5b7-4f8839efbeb4.png">


* Forking is not being used so it has been commented out 
* Uses empty string if no .env variable