### PR TITLE
Add Tests From Bond Holder's Perspective

### DIFF
--- a/deploy/integrate_bond_actions.ts
+++ b/deploy/integrate_bond_actions.ts
@@ -88,7 +88,7 @@ Executing bond actions.
             process.env.BOND_BENEFICIARY || "",
             bondConfig.maxSupply.div(2)
           ),
-        conditions: [async () => process.env.BOND_BENEFICIARY != null],
+        conditions: [async () => process.env.BOND_BENEFICIARY != ""],
       },
     ];
 

--- a/deploy/integrate_create_auctions.ts
+++ b/deploy/integrate_create_auctions.ts
@@ -94,7 +94,10 @@ auctionEndDate: ${auctionEndDate}
       });
     } catch (e) {
       console.log(e);
-      console.log(`Failed to create auction for ${address}.`);
+      console.log(
+        `Failed to create auction for ${address}.
+Are you on the network corresponding to the auction address?`
+      );
     }
   }
 };

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -979,7 +979,6 @@ describe("Bond", () => {
             });
 
             it("redeems correct amount of tokens when partially paid", async () => {
-              console.log(decimals, await bond.amountUnpaid());
               const amountUnpaid = (await bond.amountUnpaid()).div(2);
 
               await bond.pay(amountUnpaid);

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -978,7 +978,7 @@ describe("Bond", () => {
               ).to.be.revertedWith("ZeroAmount");
             });
 
-            it.only("redeems correct amount of tokens when partially paid", async () => {
+            it("redeems correct amount of tokens when partially paid", async () => {
               console.log(decimals, await bond.amountUnpaid());
               const amountUnpaid = (await bond.amountUnpaid()).div(2);
 

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -778,7 +778,7 @@ describe("Bond", () => {
           it("should redeem for payment token when bond is PaidEarly", async () => {
             await bond.pay(await bond.amountUnpaid());
             const sharesToRedeem = utils.parseUnits("1000", decimals);
-            bond.transfer(bondHolder.address, sharesToRedeem);
+            await bond.transfer(bondHolder.address, sharesToRedeem);
             await previewRedeem({
               bond,
               sharesToRedeem: sharesToRedeem,
@@ -979,7 +979,7 @@ describe("Bond", () => {
               bond.address,
               config.collateralTokenAmount
             );
-            bond.transfer(bondHolder.address, config.maxSupply);
+            await bond.transfer(bondHolder.address, config.maxSupply);
           });
 
           it("previews convert zero converted", async () => {
@@ -1045,7 +1045,7 @@ describe("Bond", () => {
           beforeEach(async () => {
             bond = bondWithTokens.nonConvertible.bond;
             config = bondWithTokens.nonConvertible.config;
-            bond.transfer(bondHolder.address, config.maxSupply);
+            await bond.transfer(bondHolder.address, config.maxSupply);
           });
 
           it("should fail to convert if bond is not convertible", async () => {
@@ -1072,7 +1072,7 @@ describe("Bond", () => {
           beforeEach(async () => {
             bond = bondWithTokens.uncollateralized.bond;
             config = bondWithTokens.uncollateralized.config;
-            bond.transfer(bondHolder.address, config.maxSupply);
+            await bond.transfer(bondHolder.address, config.maxSupply);
           });
 
           it("should fail to convert if bond is uncollateralized and therefore unconvertible", async () => {

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -354,12 +354,6 @@ describe("Bond", () => {
               bond.withdrawExcessPayment(owner.address)
             ).to.be.revertedWith("NoPaymentToWithdraw");
           });
-
-          it("fails to withdraw when called by non-owner", async () => {
-            await expect(
-              bond.connect(bondHolder).withdrawExcessPayment(owner.address)
-            ).to.be.revertedWith("Ownable: caller is not the owner");
-          });
         });
       });
 
@@ -552,17 +546,6 @@ describe("Bond", () => {
                 config.collateralTokenAmount
               );
             });
-
-            it("fails to withdraw when called by non-owner", async () => {
-              await expect(
-                bond
-                  .connect(bondHolder)
-                  .withdrawExcessCollateral(
-                    await bond.previewWithdrawExcessCollateral(),
-                    owner.address
-                  )
-              ).to.be.revertedWith("Ownable: caller is not the owner");
-            });
           });
 
           describe("convert", async () => {
@@ -595,17 +578,6 @@ describe("Bond", () => {
                 collateralToReceive,
               });
             });
-
-            it("fails to withdraw when called by non-owner", async () => {
-              await expect(
-                bond
-                  .connect(bondHolder)
-                  .withdrawExcessCollateral(
-                    await bond.previewWithdrawExcessCollateral(),
-                    owner.address
-                  )
-              ).to.be.revertedWith("Ownable: caller is not the owner");
-            });
           });
         });
         describe("Defaulted state", async () => {
@@ -620,17 +592,6 @@ describe("Bond", () => {
                 paymentTokenAmount: config.maxSupply.sub(1),
                 collateralToReceive: config.collateralTokenAmount.sub(1),
               });
-            });
-
-            it("fails to withdraw when called by non-owner", async () => {
-              await expect(
-                bond
-                  .connect(bondHolder)
-                  .withdrawExcessCollateral(
-                    await bond.previewWithdrawExcessCollateral(),
-                    owner.address
-                  )
-              ).to.be.revertedWith("Ownable: caller is not the owner");
             });
           });
         });
@@ -722,17 +683,6 @@ describe("Bond", () => {
               );
               expect(await collateralToken.balanceOf(bond.address)).to.equal(0);
             });
-
-            it("fails to withdraw when called by non-owner", async () => {
-              await expect(
-                bond
-                  .connect(bondHolder)
-                  .withdrawExcessCollateral(
-                    await bond.previewWithdrawExcessCollateral(),
-                    owner.address
-                  )
-              ).to.be.revertedWith("Ownable: caller is not the owner");
-            });
           });
           describe("convert", async () => {
             it("should have collateral required to cover convertibleRatio locked", async () => {
@@ -789,17 +739,6 @@ describe("Bond", () => {
               expect(await bond.previewWithdrawExcessCollateral()).to.equal(
                 utils.parseEther("1")
               );
-            });
-
-            it("fails to withdraw when called by non-owner", async () => {
-              await expect(
-                bond
-                  .connect(bondHolder)
-                  .withdrawExcessCollateral(
-                    await bond.previewWithdrawExcessCollateral(),
-                    owner.address
-                  )
-              ).to.be.revertedWith("Ownable: caller is not the owner");
             });
           });
         });

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -39,39 +39,41 @@ export const TWO_AND_A_HALF_MILLION = (2500000).toString();
 export const TEN_MILLION = (10000000).toString();
 // The config objects are used as anchors to test against
 
-export const NonConvertibleBondConfig: BondConfigType = {
-  collateralTokenAmount: utils.parseUnits(TEN_MILLION, 18),
+export const NonConvertibleBondConfig = (decimals: number): BondConfigType => ({
+  collateralTokenAmount: utils.parseUnits((10_000_000).toString(), decimals),
   convertibleTokenAmount: ZERO,
   maturity: THREE_YEARS_FROM_NOW_IN_SECONDS,
-  maxSupply: utils.parseUnits(FIFTY_MILLION.toString(), 18),
-};
+  maxSupply: utils.parseUnits((50_000_000).toString(), decimals),
+});
 
-export const ConvertibleBondConfig: BondConfigType = {
-  collateralTokenAmount: utils.parseUnits(TEN_MILLION, 18),
-  convertibleTokenAmount: utils.parseUnits(TWO_AND_A_HALF_MILLION, 18),
+export const ConvertibleBondConfig = (decimals: number): BondConfigType => ({
+  collateralTokenAmount: utils.parseUnits((50_000_000).toString(), decimals),
+  convertibleTokenAmount: utils.parseUnits((25_000_000).toString(), decimals),
   maturity: THREE_YEARS_FROM_NOW_IN_SECONDS,
-  maxSupply: utils.parseUnits(FIFTY_MILLION.toString(), 18),
-};
+  maxSupply: utils.parseUnits((50_000_000).toString(), decimals),
+});
 
-export const UncollateralizedBondConfig: BondConfigType = {
+export const UncollateralizedBondConfig = (
+  decimals: number
+): BondConfigType => ({
   collateralTokenAmount: ZERO,
   convertibleTokenAmount: ZERO,
   maturity: THREE_YEARS_FROM_NOW_IN_SECONDS,
-  maxSupply: utils.parseUnits(FIFTY_MILLION.toString(), 18),
-};
+  maxSupply: utils.parseUnits((50_000_000).toString(), decimals),
+});
 
-export const MaliciousBondConfig: BondConfigType = {
-  collateralTokenAmount: utils.parseUnits(TEN_MILLION, 18),
-  convertibleTokenAmount: utils.parseUnits(TWO_AND_A_HALF_MILLION, 18),
+export const MaliciousBondConfig = (decimals: number): BondConfigType => ({
+  collateralTokenAmount: utils.parseUnits((50_000_000).toString(), decimals),
+  convertibleTokenAmount: utils.parseUnits((20_000_000).toString(), decimals),
   maturity: THREE_YEARS_FROM_NOW_IN_SECONDS,
-  maxSupply: utils.parseUnits(FIFTY_MILLION.toString(), 18),
-};
+  maxSupply: utils.parseUnits((50_000_000).toString(), decimals),
+});
 
 const SHORT_MATURITY_NON_CONVERTIBLE: BondDeploymentConfiguration = {
   // This bond has a short maturity and a full FIFTY_MILLION
   // Since we pay TWENTY_FIVE_MILLION, this bond will "Default"
   bondConfig: {
-    ...NonConvertibleBondConfig,
+    ...NonConvertibleBondConfig(6),
     maturity: TEN_MINUTES_FROM_NOW_IN_SECONDS,
     maxSupply: utils.parseUnits(FIFTY_MILLION.toString(), 6),
   },
@@ -84,7 +86,7 @@ const SHORT_MATURITY_NON_CONVERTIBLE: BondDeploymentConfiguration = {
 const SHORT_MATURITY_CONVERTIBLE: BondDeploymentConfiguration = {
   // This will be an "Active" convertible bond
   bondConfig: {
-    ...ConvertibleBondConfig,
+    ...ConvertibleBondConfig(6),
     maturity: TEN_MINUTES_FROM_NOW_IN_SECONDS,
     maxSupply: utils.parseUnits(FIFTY_MILLION.toString(), 6),
   },
@@ -96,7 +98,7 @@ const SHORT_MATURITY_UNCOLLATERALIZED_SHORT_ORDER_CANCELLATION: BondDeploymentCo
   {
     // This will be an "Active" Un-Collateralized bond
     bondConfig: {
-      ...UncollateralizedBondConfig,
+      ...UncollateralizedBondConfig(6),
       maturity: TEN_MINUTES_FROM_NOW_IN_SECONDS,
       maxSupply: utils.parseUnits(FIFTY_MILLION.toString(), 6),
     },
@@ -114,7 +116,7 @@ const LONG_MATURITY_NON_CONVERTIBLE_SHORT_AUCTION_END: BondDeploymentConfigurati
   {
     // This will be an "Active" Non-Convertible bond
     bondConfig: {
-      ...NonConvertibleBondConfig,
+      ...NonConvertibleBondConfig(6),
       maturity: ONE_YEAR_FROM_NOW_IN_SECONDS,
       maxSupply: utils.parseUnits(FIFTY_MILLION.toString(), 6),
     },
@@ -134,7 +136,7 @@ const LONG_MATURITY_NON_CONVERTIBLE_SHORT_AUCTION_END_TWO_YEARS: BondDeploymentC
   {
     // This will be an "Active" Non-Convertible bond
     bondConfig: {
-      ...NonConvertibleBondConfig,
+      ...NonConvertibleBondConfig(6),
       maturity: TWO_YEARS_FROM_NOW_IN_SECONDS,
       maxSupply: utils.parseUnits(FIFTY_MILLION.toString(), 6),
     },
@@ -153,7 +155,7 @@ const LONG_MATURITY_NON_CONVERTIBLE_SHORT_AUCTION_END_TWO_YEARS: BondDeploymentC
 const LONG_MATURITY_CONVERTIBLE: BondDeploymentConfiguration = {
   // This will be a "Paid" convertible bond
   bondConfig: {
-    ...ConvertibleBondConfig,
+    ...ConvertibleBondConfig(6),
     // Make bond mature
     maturity: TEN_MINUTES_FROM_NOW_IN_SECONDS,
     // Make bond paid off (we are paying TWENTY_FIVE_MILLION in deploy)
@@ -169,7 +171,7 @@ const LONG_MATURITY_CONVERTIBLE: BondDeploymentConfiguration = {
 const LONG_MATURITY_CONVERTIBLE_LONG_AUCTION_CANCELLATION = {
   // This will be a "PaidEarly" Convertible bond
   bondConfig: {
-    ...ConvertibleBondConfig,
+    ...ConvertibleBondConfig(18),
     maturity: ONE_YEAR_FROM_NOW_IN_SECONDS,
     // Make bond paid off (we are paying TWENTY_FIVE_MILLION in deploy)
   },
@@ -187,7 +189,7 @@ const LONG_MATURITY_CONVERTIBLE_LONG_AUCTION_CANCELLATION = {
 const LONG_MATURITY_CONVERTIBLE_PAID_EARLY_LONG_AUCTION_CANCELLATION = {
   // This will be a "PaidEarly" Convertible bond
   bondConfig: {
-    ...ConvertibleBondConfig,
+    ...ConvertibleBondConfig(6),
     maturity: THREE_YEARS_FROM_NOW_IN_SECONDS,
     // Make bond paid off (we are paying TWENTY_FIVE_MILLION in deploy)
     maxSupply: utils.parseUnits(TWENTY_FIVE_MILLION.toString(), 6),

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -64,7 +64,6 @@ export const getBondContract = async (
     tx,
     "BondCreated"
   );
-
   return (await ethers.getContractAt("Bond", newBondAddress, owner)) as Bond;
 };
 
@@ -148,15 +147,19 @@ export const redeemAndCheckTokens = async ({
   paymentTokenToSend: BigNumber;
   collateralTokenToSend: BigNumber;
 }) => {
-  const redeemTransaction = bond.connect(bondHolder).redeem(sharesToRedeem);
-  expect(redeemTransaction).to.changeTokenBalance(
-    collateralTokenToSend,
-    bondHolder,
+  const collateralBalanceBefore = await collateralToken.balanceOf(
+    bondHolder.address
+  );
+  const paymentBalanceBefore = await paymentToken.balanceOf(bondHolder.address);
+  await bond.connect(bondHolder).redeem(sharesToRedeem);
+  const collateralBalanceAfter = await collateralToken.balanceOf(
+    bondHolder.address
+  );
+  const paymentBalanceAfter = await paymentToken.balanceOf(bondHolder.address);
+  expect(collateralBalanceAfter.sub(collateralBalanceBefore).abs()).to.equal(
     collateralTokenToSend
   );
-  expect(redeemTransaction).to.changeTokenBalance(
-    paymentTokenToSend,
-    bondHolder,
+  expect(paymentBalanceAfter.sub(paymentBalanceBefore).abs()).to.equal(
     paymentTokenToSend
   );
 };


### PR DESCRIPTION
Where it makes sense, the `bondHolder` signer should be used instead of the `issuer`. By default the `issuer` signs transactions within the test.  `.connect(bondHolder)` uses the bond holder's address to perform actions. To get this to work in most places, the `issuer` must `transfer` tokens to the bond holder and then the bond holder can perform the actions.

In addition to this, I found a bug in the expecting token balance changes. Because there was no `await` on the function, the tests were false positives. This uncovered a problem with how we were handling decimals in the test config max supply (18 decimals for all of them). 

These configs are now also dynamically made in the fixture.

closes #294