### PR TITLE
fix failing test due to rounding

### DIFF
--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -1002,18 +1002,19 @@ describe("Bond", () => {
               ).to.be.revertedWith("ZeroAmount");
             });
 
-            it("should allow redemption of payment token when bond is partially paid and Defaulted", async () => {
-              const paymentAmount = utils.parseUnits("400000", decimals);
-              await bond.pay(paymentAmount);
+            it.only("redeems correct amount of tokens when partially paid", async () => {
+              console.log(decimals, await bond.amountUnpaid());
+              const amountUnpaid = (await bond.amountUnpaid()).div(2);
 
-              const portionOfTotalBonds = utils
-                .parseUnits("400000", decimals)
+              await bond.pay(amountUnpaid);
+
+              const portionOfTotalBonds = amountUnpaid
                 .mul(ONE)
                 .div(config.maxSupply);
               const portionOfPaymentAmount = portionOfTotalBonds
-                .mul(paymentAmount)
+                .mul(amountUnpaid)
                 .div(ONE);
-              const sharesToRedeem = utils.parseUnits("400000", decimals);
+              const sharesToRedeem = amountUnpaid;
 
               await bond.transfer(bondHolder.address, sharesToRedeem);
               await redeemAndCheckTokens({


### PR DESCRIPTION
This fixes the failing test. 

This was failing because the maxSupply was a hardcoded 18 decimal number. 

Previously, we were paying 400k * 10^6 when 50m * 10^18 was due (effectively paying ~.0000000000000000001%) which caused redeem to round down to zero when calculating the redeem amount. 

<img width="445" alt="image" src="https://user-images.githubusercontent.com/15036618/168287487-fced1cd4-86c8-48cb-8d0f-613c66811fe5.png">

Note: You make want to improve this test, I only focused on fixing the error

Please merge if you like this :) 